### PR TITLE
bugfix: ModDotPlot Cen Plotting Workflow Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 *.env
 *.sif
 .snakemake
-logs/
-results/
-benchmarks/
+logs*/
+results*/
+benchmarks*/
 venv/
-temp/
+temp*/
 
 RM_*
 .RepeatMaskerCache/

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -119,4 +119,5 @@ calculate_hor_length:
 moddotplot:
   input_dir: null
   output_dir: "results/moddotplot"
+  mem: 10
   window: 5000

--- a/test/config/config.yaml
+++ b/test/config/config.yaml
@@ -85,4 +85,5 @@ calculate_hor_length:
 moddotplot:
   input_dir: null
   output_dir: "results/moddotplot"
+  mem: 10
   window: 5000

--- a/workflow/rules/moddotplot.smk
+++ b/workflow/rules/moddotplot.smk
@@ -28,6 +28,8 @@ rule run_moddotplot:
         window=config["moddotplot"]["window"],
         ident_thr=70.0,
         outdir=lambda wc: os.path.join(OUTPUT_MODDOTPLOT_DIR, f"original_{wc.fname}"),
+    resources:
+        mem=config["moddotplot"]["mem"],
     log:
         "logs/moddotplot/moddotplot_{fname}.log",
     benchmark:
@@ -111,7 +113,7 @@ def moddotplot_outputs_no_input_dir(wc):
                 zip,
                 fname=fnames,
                 chr=chrs,
-                mer_order="{mer_order}",
+                mer_order=["{mer_order}"] * len(fnames),
             ),
             mer_order=config["plot_hor_stv"]["mer_order"],
         ),
@@ -143,7 +145,7 @@ else:
                     zip,
                     fname=fnames,
                     chr=chrs,
-                    mer_order="{mer_order}",
+                    mer_order=["{mer_order}"] * len(fnames),
                 ),
                 mer_order=config["plot_hor_stv"]["mer_order"],
             ),

--- a/workflow/rules/repeatmasker.smk
+++ b/workflow/rules/repeatmasker.smk
@@ -80,8 +80,8 @@ rule rename_for_repeatmasker:
         "logs/repeatmasker/rename_for_repeatmasker_{sm}.log",
     shell:
         """
-        seqtk rename {input.fa} {params.prefix} > {output} 2> {log}
-        samtools faidx {output} 2>> {log}
+        seqtk rename {input.fa} {params.prefix} > {output.renamed_fa} 2> {log}
+        samtools faidx {output.renamed_fa} 2>> {log}
         """
 
 

--- a/workflow/scripts/repeatStructure.R
+++ b/workflow/scripts/repeatStructure.R
@@ -61,7 +61,7 @@ p <- add_argument(p, "--mer_order",
 
 argv <- parse_args(p)
 
-df_rm_sat_out <- read_repeatmasker_sat_input(argv$input_rm_sat)
+df_rm_sat_out <- read_multiple_repeatmasker_sat_input(argv$input_rm_sat)
 # Filter out chr without annotations.
 df_humas_hmmer_stv_out <- read_multiple_humas_hmmer_input(
   argv$input_stv,


### PR DESCRIPTION
* Fixed mer_order wildcard not expanding correctly.
* Fixed contig coordinates with non-rc contigs in plotting script.
* Added width and height args to plotting script.
* Allowed specifying memory for ModDotPlot.
* Fix command for renaming RepeatMasker input fa.