### PR TITLE
hotfix: Remove empty fasta check and fix colors

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -25,7 +25,6 @@ def extract_fa_fnames_and_chr(input_dir: str) -> tuple[list[str], list[str]]:
     assert len(fnames) == len(
         chrs
     ), f"One or more fa files in {input_dir} does not contain a chromosome in its name."
-    assert len(chrs) > 0, f"No fa files found in {input_dir}."
 
     return fnames, chrs
 

--- a/workflow/scripts/r_utils/repeats.R
+++ b/workflow/scripts/r_utils/repeats.R
@@ -39,7 +39,7 @@ get_rm_sat_annot_colors <- function() {
 plot_single_ctg <- function(ctg, df_rm_sat_out, df_humas_hmmer_stv_out, height = 10) {
   p <- ggplot(data = df_rm_sat_out[order(df_rm_sat_out$region), ] %>% filter(chr == ctg)) +
     geom_segment(
-      aes(x = start2, y = chr, xend = stop2, yend = chr, color = region),
+      aes(x = start2, y = chr, xend = stop2 + 1000, yend = chr, color = region),
       alpha = 1,
       size = height
     ) +
@@ -49,7 +49,7 @@ plot_single_ctg <- function(ctg, df_rm_sat_out, df_humas_hmmer_stv_out, height =
     new_scale_color() +
     geom_segment(
       data = df_humas_hmmer_stv_out %>% filter(chr == ctg),
-      aes(x = start, xend = stop, y = chr, yend = chr, color = as.factor(mer)),
+      aes(x = start, xend = stop + 2000, y = chr, yend = chr, color = as.factor(mer)),
       size = height
     ) +
     scale_color_manual(values = get_humas_hmmer_stv_annot_colors()) +
@@ -74,7 +74,7 @@ plot_single_ctg <- function(ctg, df_rm_sat_out, df_humas_hmmer_stv_out, height =
 plot_all_ctgs <- function(df_rm_sat_out, df_humas_hmmer_stv_out, height = 10) {
   p <- ggplot(data = df_rm_sat_out[order(df_rm_sat_out$region), ]) +
     geom_segment(
-      aes(x = start2, y = chr, xend = stop2, yend = chr, color = region),
+      aes(x = start2, y = chr, xend = stop2 + 1000, yend = chr, color = region),
       alpha = 1,
       size = height
     ) +
@@ -84,7 +84,7 @@ plot_all_ctgs <- function(df_rm_sat_out, df_humas_hmmer_stv_out, height = 10) {
     new_scale_color() +
     geom_segment(
       data = df_humas_hmmer_stv_out,
-      aes(x = start, xend = stop, y = chr, yend = chr, color = as.factor(mer)),
+      aes(x = start, xend = stop + 2000, y = chr, yend = chr, color = as.factor(mer)),
       size = height
     ) +
     scale_color_manual(values = get_humas_hmmer_stv_annot_colors()) +


### PR DESCRIPTION
* Remove secondary assertion when getting filenames and chr names for ModDotPlot.
    * Fixes #40  
* Fix centromere HOR monomer colors by adding extra bases to highlight colors.
    * Fixes #41  