### PR TITLE
bugfix: Missing chr16 Centromeres

### DIFF
--- a/config/dnabrnn_thresholds.json
+++ b/config/dnabrnn_thresholds.json
@@ -1,8 +1,7 @@
 {
     "repeat_len_thr": {
         "chr9": [[9000, 10000], [1000000, null]],
-        "chr10": [[2000, null]],
-        "chr16": [[1000000, null]]
+        "chr10": [[2000, null]]
     },
     "min_repeat_len_perc": 0.5,
     "default_repeat_len_thr": [1000, null]

--- a/workflow/rules/fix_cens_w_repeatmasker.smk
+++ b/workflow/rules/fix_cens_w_repeatmasker.smk
@@ -10,8 +10,8 @@ rule check_cens_status:
             config["repeatmasker"]["output_dir"], "status", "{chr}_cens_status.tsv"
         ),
     params:
-        edge_len=100_000,
-        edge_perc_alr_thr=0.70,
+        edge_len=lambda wc: 100_000 if wc.chr != "chr16" else 300_000,
+        edge_perc_alr_thr=lambda wc: 0.70 if wc.chr != "chr16" else 0.95,
         dst_perc_thr=0.3,
         # Edge-case for chrs whose repeats are small and broken up.
         max_alr_len_thr=lambda wc: 0 if wc.chr in ["chrY", "chr11", "chr8"] else 30_000,

--- a/workflow/rules/moddotplot.smk
+++ b/workflow/rules/moddotplot.smk
@@ -104,6 +104,9 @@ def moddotplot_outputs_no_input_dir(wc):
 
     fnames, chrs = extract_fa_fnames_and_chr(config["humas_hmmer"]["input_dir"])
 
+    wildcard_constraints:
+        fname="|".join(fnames),
+
     return dict(
         modotplot=expand(rules.run_moddotplot.output, fname=fnames),
         cen_moddoplot=expand(

--- a/workflow/rules/repeatmasker.smk
+++ b/workflow/rules/repeatmasker.smk
@@ -83,7 +83,11 @@ rule rename_for_repeatmasker:
     shell:
         """
         seqtk rename {input.fa} {params.prefix} > {output.renamed_fa} 2> {log}
-        samtools faidx {output.renamed_fa} 2>> {log}
+        if [ -s {output.renamed_fa} ]; then
+            samtools faidx {output.renamed_fa} 2>> {log}
+        else
+            touch {output.renamed_fa_idx}
+        fi
         """
 
 
@@ -112,12 +116,16 @@ rule run_repeatmasker:
         "benchmarks/repeatmasker/repeatmasker_{sm}.tsv"
     shell:
         """
-        RepeatMasker \
-        -engine {params.engine} \
-        -species {params.species} \
-        -dir {params.output_dir} \
-        -pa {threads} \
-        {input.seq} &> {log}
+        if [ -s {input.seq} ]; then
+            RepeatMasker \
+            -engine {params.engine} \
+            -species {params.species} \
+            -dir {params.output_dir} \
+            -pa {threads} \
+            {input.seq} &> {log}
+        else
+            touch {output}
+        fi
         """
 
 

--- a/workflow/scripts/filter_dnabrnn_output.py
+++ b/workflow/scripts/filter_dnabrnn_output.py
@@ -167,10 +167,13 @@ def main():
         largest_row = df_ctg.filter(pl.col("rlen") == pl.col("rlen").max()).to_dict()
 
         # Allow only repeats some number of bps from the largest detected alpha-sat repeat.
-        df_ctg = df_ctg.filter(
-            (pl.col("start") > largest_row["start"] - args.dst_from_largest)
-            & (pl.col("end") < largest_row["end"] + args.dst_from_largest)
-        )
+        try:
+            df_ctg = df_ctg.filter(
+                (pl.col("start") > largest_row["start"][0] - args.dst_from_largest)
+                & (pl.col("end") < largest_row["end"][0] + args.dst_from_largest)
+            )
+        except IndexError:
+            pass
 
         dfs.append(df_ctg)
 

--- a/workflow/scripts/reformat_rm.py
+++ b/workflow/scripts/reformat_rm.py
@@ -47,8 +47,13 @@ def main():
         open(args.infile, "rt") as infile,
     ):
         # Skip first four lines.
-        for _ in range(3):
-            next(infile)
+        try:
+            for _ in range(3):
+                next(infile)
+        except StopIteration:
+            # If empty file.
+            return
+
         rm_writer = csv.writer(args.outfile, delimiter="\t")
         for line in infile.readlines():
             line = line.strip().split()


### PR DESCRIPTION
* Fixed dnabrnn threshold for chr16 causing all repeats to be removed.
    * Resolves #48  
* Added edge-case params for chr16 for `CenStats` `status`.
* Adjust some scripts/commands to allow running one chromosome.
* Add `fname` wildcard constraint for moddotplot workflow.