### PR TITLE
feat: RepeatMasker before NucFlag

### DIFF
--- a/config/censtats.json
+++ b/config/censtats.json
@@ -1,0 +1,21 @@
+{
+    "edge_len": {
+        "chr4": 100000,
+        "chr6": 100000,
+        "chr14": 100000,
+        "chrY": 100000,
+        "chr13": 100000,
+        "default": 500000
+    },
+    "edge_perc_alr_thr": {
+        "chr7": 0.8,
+        "default": 0.95
+    },
+    "max_alr_len_thr": {
+        "chrY": 0,
+        "chr11": 0,
+        "chr8": 0,
+        "chrX": 0,
+        "default": 250000
+    }
+}

--- a/config/censtats.json
+++ b/config/censtats.json
@@ -4,18 +4,15 @@
         "chr6": 100000,
         "chr14": 100000,
         "chrY": 100000,
-        "chr13": 100000,
-        "default": 500000
+        "chr13": 100000
     },
     "edge_perc_alr_thr": {
-        "chr7": 0.8,
-        "default": 0.95
+        "chr7": 0.8
     },
     "max_alr_len_thr": {
         "chrY": 0,
         "chr11": 0,
         "chr8": 0,
-        "chrX": 0,
-        "default": 250000
+        "chrX": 0
     }
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -66,14 +66,12 @@ new_cens:
   output_dir: "results/cens_new"
 
 nucflag:
-  # # Or an fofn dir where {hifi_reads_fofn_dir}/{sm}.fofn
-  # hifi_reads_fofn_dir: "data/raw_data_link"
-  hifi_reads_dir: "data/raw_data_link"
-  reads_ext: "fastq.gz"
+  hifi_reads_fofn_dir: "data/hifi"
+ # hifi_reads_dir: "data/hifi"
+ # reads_ext: "fastq.gz"
   output_dir: "results/nucflag"
   tmp_dir: "temp"
   config_nucflag: "config/nucflag.toml"
-  ignore_regions: "config/nucflag_ignore.bed"
   threads_aln: 24
   processes_nucflag: 12
   mem_nucflag: 50

--- a/config/config_hifiasm.yaml
+++ b/config/config_hifiasm.yaml
@@ -25,24 +25,88 @@ chromosomes:
   - "chrY"
 
 samples:
+  - HG00096
   - HG00171
+  - HG00268
+  - HG00512
+  - HG00513
+  - HG00514
+  - HG00733
+  - HG00864
+  - NA19240
+  - NA18939
+  - NA12329
+  - HG00358
+  - HG00731
+  - HG00732
+  - HG01114
+  - HG01352
+  - HG01457
+  - HG01505
+  - HG01573
+  - HG01596
+  - HG01890
+  - HG02011
+  - HG02018
+  - HG02059
+  - HG02106
+  - HG02282
+  - HG02492
+  - HG02554
+  - HG02587
+  - HG02666
+  - HG02769
+  - HG02818
+  - HG02953
+  - HG03009
+  - HG03065
+  - HG03248
+  - HG03371
+  - HG03452
+  - HG03456
+  - HG03520
+  - HG03683
+  - HG03732
+  - HG03807
+  - HG04036
+  - HG04217
+  - NA18534
+  - NA18989
+  - NA19036
+  - NA19129
+  - NA19238
+  - NA19239
+  - NA19317
+  - NA19331
+  - NA19347
+  - NA19384
+  - NA19434
+  - NA19650
+  - NA19705
+  - NA19836
+  - NA19983
+  - NA20355
+  - NA20509
+  - NA20847
+  - NA21487
+  - NA24385
 
 concat_asm:
   # Expects {input_dir}/{sm}/*.gz
-  input_dir: "data/assemblies"
-  output_dir: "data/assemblies/combined"
+  input_dir: "data/assemblies_link"
+  output_dir: "results/assemblies/combined"
   mem: 20
 
 align_asm_to_ref:
   # Output dir set to results
-  reference: "data/reference/T2T-CHM13v2.fasta.gz"
+  reference: "data/reference/T2T-CHM13v2.fasta"
   threads: 4
-  mem: 60
+  mem: 120
 
 extract_ref_hor_arrays:
   output_dir: "results/ref_hor_arrays"
   # Add bp to extend edges of HOR array for alignment.
-  added_bases: 0
+  added_bases: 100_000
 
 ident_cen_ctgs:
   comb_assemblies_dir: "data/assemblies/combined"
@@ -66,12 +130,12 @@ new_cens:
   output_dir: "results/cens_new"
 
 nucflag:
-  hifi_reads_fofn_dir: "data/hifi"
- # hifi_reads_dir: "data/hifi"
- # reads_ext: "fastq.gz"
+  hifi_reads_dir: "data/raw_data_link"
+  reads_ext: "fastq.gz"
   output_dir: "results/nucflag"
   tmp_dir: "temp"
   config_nucflag: "config/nucflag.toml"
+  ignore_regions: "config/nucflag_ignore.bed"
   threads_aln: 24
   processes_nucflag: 12
   mem_nucflag: 50
@@ -81,16 +145,16 @@ nucflag:
 repeatmasker:
   ref_repeatmasker_chrY_output: data/annotations/cenSat_Annotations_HORs.maxmin.v2.0.chrY.500kbp.fa.out
   ref_repeatmasker_output: data/annotations/chm13_chm1_cens_v21.trimmed.fa.noheader.out
-  config_censtats_status: "config/censtats.json"
   threads: 12
   output_dir: "results/repeatmasker"
+  config_censtats_status: "config/censtats.json"
 
 humas_hmmer:
   # Dir where split cens placed.
   input_dir: "results/humas_hmmer/cens"
   output_dir: "results/humas_hmmer"
   # NOTE: If providing 150 cores and num_threads=30, a max of 5 are run concurrently.
-  threads: 24
+  threads: 6
   model: "data/models/AS-HORs-hmmer3.0-170921.hmm"
 
 plot_hor_stv:
@@ -114,8 +178,8 @@ count_complete_cens:
   plot_lbl: null
   plot_color: "#DA8B26"
 
-moddotplot:
-  input_dir: null
-  output_dir: "results/moddotplot"
-  mem: 10
-  window: 5000
+# moddotplot:
+#   input_dir: null
+#   output_dir: "results/moddotplot"
+#   mem: 10
+#   window: 5000

--- a/config/nucflag.toml
+++ b/config/nucflag.toml
@@ -33,9 +33,9 @@ thr_collapse_peak = 2.5
 
 # Group consecutive positions allowing a maximum gap of x.
 # Larger value groups more positions.
-valley_group_distance = 5_000
+valley_group_distance = 500
 
-peak_group_distance = 5_000
+peak_group_distance = 500
 
 [second]
 # Percent threshold of most freq base to allow second most freq base
@@ -50,7 +50,7 @@ thr_peak_height_std_above = 3
 group_distance = 30_000
 
 # Min group size.
-thr_min_group_size = 3
+thr_min_group_size = 5
 
 [gaps]
 thr_max_allowed_gap_size = 0

--- a/config/nucflag.toml
+++ b/config/nucflag.toml
@@ -29,7 +29,7 @@ thr_misjoin_valley = 0.2
 # * ex. 3.0 => Peaks where minimum is greater than or equal to 300% of mean
 # If int:
 # * ex. 40 => Peaks with minimum above 40
-thr_collapse_peak = 2.0
+thr_collapse_peak = 2.5
 
 # Group consecutive positions allowing a maximum gap of x.
 # Larger value groups more positions.

--- a/config/nucflag_ignore.bed
+++ b/config/nucflag_ignore.bed
@@ -1,2 +1,0 @@
-all	0	500000	pericentromere	ignore:relative
-all	-500000	0	pericentromere	ignore:relative

--- a/test/config/config.yaml
+++ b/test/config/config.yaml
@@ -51,6 +51,7 @@ repeatmasker:
   ref_repeatmasker_chrY_output: data/annotations/cenSat_Annotations_HORs.maxmin.v2.0.chrY.500kbp.fa.out
   threads: 40
   output_dir: "results/repeatmasker"
+  config_censtats_status: "config/censtats.json"
 
 humas_hmmer:
   input_dir: "data/chr_cens"

--- a/test/config/config_HG00731.yaml
+++ b/test/config/config_HG00731.yaml
@@ -51,6 +51,7 @@ repeatmasker:
   ref_repeatmasker_chrY_output: data/annotations/cenSat_Annotations_HORs.maxmin.v2.0.chrY.500kbp.fa.out
   threads: 4
   output_dir: "results/repeatmasker"
+  config_censtats_status: "config/censtats.json"
 
 humas_hmmer:
   input_dir: "results/humas_hmmer/cens"

--- a/test/config/nucflag.toml
+++ b/test/config/nucflag.toml
@@ -9,26 +9,33 @@ thr_min_peak_width = 20
 thr_min_valley_horizontal_distance = 1
 
 # Min width of valley to consider.
-thr_min_valley_width = 5
+thr_min_valley_width = 3
 
 # Number of std above mean to include peak.
-thr_peak_height_std_above = 4
+thr_peak_height_std_above = 3
 
 # Number of std below mean to include valley.
-thr_valley_height_std_below = 4
+thr_valley_height_std_below = 2
 
 # Valleys with coverage below this threshold are considered misjoins.
 # If float:
-# * ex. 0.1 => Valley where median is less than or equal to 10% of mean
+# * ex. 0.1 => Valley where minimum is less than or equal to 10% of mean
 # If int:
-# * ex. 2 => Valleys with median below 2
+# * ex. 2 => Valleys with minimum below 2
 thr_misjoin_valley = 0.2
+
+# Peaks with coverage above this threshold are considered collapses w/no variants.
+# If float:
+# * ex. 3.0 => Peaks where minimum is greater than or equal to 300% of mean
+# If int:
+# * ex. 40 => Peaks with minimum above 40
+thr_collapse_peak = 3.0
 
 # Group consecutive positions allowing a maximum gap of x.
 # Larger value groups more positions.
-valley_group_distance = 5000
+valley_group_distance = 5_000
 
-peak_group_distance = 5000
+peak_group_distance = 5_000
 
 [second]
 # Percent threshold of most freq base to allow second most freq base
@@ -36,17 +43,14 @@ peak_group_distance = 5000
 thr_min_perc_first = 0.1
 
 # Number of std above mean to include peak.
-thr_peak_height_std_above = 4
+thr_peak_height_std_above = 3
 
 # Group consecutive positions allowing a maximum gap of x.
 # Larger value groups more positions.
-group_distance = 5_000
+group_distance = 30_000
 
 # Min group size.
-thr_min_group_size = 10
-
-# Het ratio to consider second group a collapse if no overlaps in peaks found.
-thr_collapse_het_ratio = 0.2
+thr_min_group_size = 3
 
 [gaps]
 thr_max_allowed_gap_size = 0

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -2,7 +2,7 @@ from snakemake.utils import min_version
 
 
 min_version("6.0")
-shell.prefix("set -euo pipefail; ")
+shell.prefix("set -euo pipefail;")
 
 
 # Constants loaded here.

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -24,6 +24,7 @@ include: "rules/ident_cen_ctgs.smk"
 include: "rules/dna_brnn.smk"
 include: "rules/extract_new_cens_ctgs.smk"
 include: "rules/repeatmasker.smk"
+include: "rules/fix_cens_w_repeatmasker.smk"
 include: "rules/humas_hmmer.smk"
 
 
@@ -41,6 +42,7 @@ output = [
     rules.dna_brnn_all.input,
     rules.extract_new_cens_all.input,
     rules.repeatmasker_only.input,
+    rules.fix_cens_w_repeatmasker_only.input,
     rules.humas_hmmer_only.input,
 ]
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -5,13 +5,83 @@ import glob
 from collections import defaultdict
 
 
-with open(config["dna_brnn"]["full_alr_thr_file"]) as fh:
-    DNA_BRNN_FULL_ALR_THRS = json.load(fh)
-    DNA_BRNN_DEF_FULL_ALR_THR = DNA_BRNN_FULL_ALR_THRS.get("default", 1_000_000)
+# Include contants so can run individual smk files without main Snakefile.
+include: "constants.smk"
 
 
-def alr_region_threshold(wc) -> int:
+# TODO: Migrate to YAML and use Snakemake built-in config validators.
+try:
+    with open(config["dna_brnn"]["full_alr_thr_file"]) as fh:
+        DNA_BRNN_FULL_ALR_THRS = json.load(fh)
+        DNA_BRNN_DEF_FULL_ALR_THR = DNA_BRNN_FULL_ALR_THRS.get(
+            "default", DEF_DNA_BRNN_FULL_ALR_THR
+        )
+except (KeyError, FileNotFoundError):
+    DNA_BRNN_FULL_ALR_THRS = {c: DEF_DNA_BRNN_FULL_ALR_THR for c in CHROMOSOMES}
+except json.decoder.JSONDecodeError as json_err:
+    raise Exception(
+        f"Invalid JSON configuration for {config['dna_brnn']['full_alr_thr_file']}: {json_err}"
+    )
+
+try:
+    with open(config["repeatmasker"]["config_censtats_status"]) as fh:
+        CENSTATS_STATUS_CFG = json.load(fh)
+        # Edge length to evaluate
+        CENSTATS_STATUS_FULL_EDGE_LEN_THR = CENSTATS_STATUS_CFG["edge_len"]
+        CENSTATS_STATUS_DEF_EDGE_LEN_THR = CENSTATS_STATUS_FULL_EDGE_LEN_THR.get(
+            "default", DEF_CENSTATS_STATUS_EDGE_LEN_THR
+        )
+        # Edge percent alpha-satellite repeat threshold to be considered partial.
+        CENSTATS_STATUS_FULL_EDGE_PERC_ALR_THR = CENSTATS_STATUS_CFG[
+            "edge_perc_alr_thr"
+        ]
+        CENSTATS_STATUS_DEF_EDGE_PERC_ALR_THR = (
+            CENSTATS_STATUS_FULL_EDGE_PERC_ALR_THR.get(
+                "default", DEF_CENSTATS_STATUS_EDGE_PERC_ALR_THR
+            )
+        )
+        # Max required alpha-satellite repeat length threshold
+        # Smaller thresholds are edge-case for chrs whose repeats are small and broken up.
+        CENSTATS_STATUS_FULL_MAX_ALR_LEN_THR = CENSTATS_STATUS_CFG["max_alr_len_thr"]
+        CENSTATS_STATUS_DEF_MAX_ALR_LEN_THR = CENSTATS_STATUS_FULL_MAX_ALR_LEN_THR.get(
+            "default", DEF_CENSTATS_STATUS_MAX_ALR_LEN_THR
+        )
+except (KeyError, FileNotFoundError):
+    CENSTATS_STATUS_FULL_EDGE_LEN_THR = {
+        c: DEF_CENSTATS_STATUS_EDGE_LEN_THR for c in CHROMOSOMES
+    }
+    CENSTATS_STATUS_FULL_EDGE_PERC_ALR_THR = {
+        c: DEF_CENSTATS_STATUS_EDGE_PERC_ALR_THR for c in CHROMOSOMES
+    }
+    CENSTATS_STATUS_FULL_MAX_ALR_LEN_THR = {
+        c: DEF_CENSTATS_STATUS_MAX_ALR_LEN_THR for c in CHROMOSOMES
+    }
+except json.decoder.JSONDecodeError as json_err:
+    raise Exception(
+        f"Invalid JSON configuration for {config['dna_brnn']['config_censtats_status_status']}: {json_err}"
+    )
+
+
+def dnabrnn_alr_region_threshold(wc) -> int:
     return DNA_BRNN_FULL_ALR_THRS.get(str(wc.chr), DNA_BRNN_DEF_FULL_ALR_THR)
+
+
+def censtats_status_edge_len(wc) -> int:
+    return CENSTATS_STATUS_FULL_EDGE_LEN_THR.get(
+        str(wc.chr), CENSTATS_STATUS_DEF_EDGE_LEN_THR
+    )
+
+
+def censtats_status_edge_perc_alr_thr(wc) -> int:
+    return CENSTATS_STATUS_FULL_EDGE_PERC_ALR_THR.get(
+        str(wc.chr), CENSTATS_STATUS_DEF_EDGE_PERC_ALR_THR
+    )
+
+
+def censtats_status_max_alr_len_thr(wc) -> int:
+    return CENSTATS_STATUS_FULL_MAX_ALR_LEN_THR.get(
+        str(wc.chr), CENSTATS_STATUS_DEF_MAX_ALR_LEN_THR
+    )
 
 
 def extract_fa_fnames_and_chr(input_dir: str) -> tuple[list[str], list[str]]:
@@ -27,7 +97,3 @@ def extract_fa_fnames_and_chr(input_dir: str) -> tuple[list[str], list[str]]:
     ), f"One or more fa files in {input_dir} does not contain a chromosome in its name."
 
     return fnames, chrs
-
-
-# Include contants so can run individual smk files without main Snakefile.
-include: "constants.smk"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -28,24 +28,13 @@ try:
         CENSTATS_STATUS_CFG = json.load(fh)
         # Edge length to evaluate
         CENSTATS_STATUS_FULL_EDGE_LEN_THR = CENSTATS_STATUS_CFG["edge_len"]
-        CENSTATS_STATUS_DEF_EDGE_LEN_THR = CENSTATS_STATUS_FULL_EDGE_LEN_THR.get(
-            "default", DEF_CENSTATS_STATUS_EDGE_LEN_THR
-        )
         # Edge percent alpha-satellite repeat threshold to be considered partial.
         CENSTATS_STATUS_FULL_EDGE_PERC_ALR_THR = CENSTATS_STATUS_CFG[
             "edge_perc_alr_thr"
         ]
-        CENSTATS_STATUS_DEF_EDGE_PERC_ALR_THR = (
-            CENSTATS_STATUS_FULL_EDGE_PERC_ALR_THR.get(
-                "default", DEF_CENSTATS_STATUS_EDGE_PERC_ALR_THR
-            )
-        )
         # Max required alpha-satellite repeat length threshold
         # Smaller thresholds are edge-case for chrs whose repeats are small and broken up.
         CENSTATS_STATUS_FULL_MAX_ALR_LEN_THR = CENSTATS_STATUS_CFG["max_alr_len_thr"]
-        CENSTATS_STATUS_DEF_MAX_ALR_LEN_THR = CENSTATS_STATUS_FULL_MAX_ALR_LEN_THR.get(
-            "default", DEF_CENSTATS_STATUS_MAX_ALR_LEN_THR
-        )
 except (KeyError, FileNotFoundError):
     CENSTATS_STATUS_FULL_EDGE_LEN_THR = {
         c: DEF_CENSTATS_STATUS_EDGE_LEN_THR for c in CHROMOSOMES
@@ -68,19 +57,19 @@ def dnabrnn_alr_region_threshold(wc) -> int:
 
 def censtats_status_edge_len(wc) -> int:
     return CENSTATS_STATUS_FULL_EDGE_LEN_THR.get(
-        str(wc.chr), CENSTATS_STATUS_DEF_EDGE_LEN_THR
+        str(wc.chr), DEF_CENSTATS_STATUS_EDGE_LEN_THR
     )
 
 
 def censtats_status_edge_perc_alr_thr(wc) -> int:
     return CENSTATS_STATUS_FULL_EDGE_PERC_ALR_THR.get(
-        str(wc.chr), CENSTATS_STATUS_DEF_EDGE_PERC_ALR_THR
+        str(wc.chr), DEF_CENSTATS_STATUS_EDGE_PERC_ALR_THR
     )
 
 
 def censtats_status_max_alr_len_thr(wc) -> int:
     return CENSTATS_STATUS_FULL_MAX_ALR_LEN_THR.get(
-        str(wc.chr), CENSTATS_STATUS_DEF_MAX_ALR_LEN_THR
+        str(wc.chr), DEF_CENSTATS_STATUS_MAX_ALR_LEN_THR
     )
 
 

--- a/workflow/rules/constants.smk
+++ b/workflow/rules/constants.smk
@@ -44,3 +44,9 @@ else:
 REF_CENS_EDGE_LEN = round(
     (500_000 + config["extract_ref_hor_arrays"].get("added_bases", 0)) / 1000
 )
+
+# Thresholds
+DEF_DNA_BRNN_FULL_ALR_THR = 30_000
+DEF_CENSTATS_STATUS_EDGE_LEN_THR = 500_000
+DEF_CENSTATS_STATUS_EDGE_PERC_ALR_THR = 0.95
+DEF_CENSTATS_STATUS_MAX_ALR_LEN_THR = 250_000

--- a/workflow/rules/dna_brnn.smk
+++ b/workflow/rules/dna_brnn.smk
@@ -140,7 +140,7 @@ rule aggregate_dnabrnn_alr_regions_by_chr:
             "{chr}_contigs.ALR.bed",
         ),
     params:
-        repeat_len_thr=alr_region_threshold,
+        repeat_len_thr=dnabrnn_alr_region_threshold,
         input_cols=" ".join(
             [
                 "chr",

--- a/workflow/rules/fix_cens_w_repeatmasker.smk
+++ b/workflow/rules/fix_cens_w_repeatmasker.smk
@@ -27,7 +27,7 @@ rule check_cens_status:
         edge_perc_alr_thr=lambda wc: 0.8 if wc.chr in ["chr7"] else 0.95,
         dst_perc_thr=0.3,
         # Edge-case for chrs whose repeats are small and broken up.
-        max_alr_len_thr=lambda wc: 0 if wc.chr in ["chrY", "chr11", "chr8"] else 250_000,
+        max_alr_len_thr=lambda wc: 0 if wc.chr in ["chrY", "chr11", "chr8", "chrX"] else 250_000,
         # Only allow mapping changes to 13 and 21 if chr13 or chr21.
         restrict_13_21="--restrict_13_21",
     log:

--- a/workflow/rules/fix_cens_w_repeatmasker.smk
+++ b/workflow/rules/fix_cens_w_repeatmasker.smk
@@ -21,13 +21,10 @@ rule check_cens_status:
             config["repeatmasker"]["output_dir"], "status", "{chr}_cens_status.tsv"
         ),
     params:
-        edge_len=lambda wc: (
-            100_000 if wc.chr in ["chr4", "chr6", "chr14", "chrY"] else 500_000
-        ),
-        edge_perc_alr_thr=lambda wc: 0.8 if wc.chr in ["chr7"] else 0.95,
+        edge_len=censtats_status_edge_len,
+        edge_perc_alr_thr=censtats_status_edge_perc_alr_thr,
         dst_perc_thr=0.3,
-        # Edge-case for chrs whose repeats are small and broken up.
-        max_alr_len_thr=lambda wc: 0 if wc.chr in ["chrY", "chr11", "chr8", "chrX"] else 250_000,
+        max_alr_len_thr=censtats_status_max_alr_len_thr,
         # Only allow mapping changes to 13 and 21 if chr13 or chr21.
         restrict_13_21="--restrict_13_21",
     log:

--- a/workflow/rules/fix_cens_w_repeatmasker.smk
+++ b/workflow/rules/fix_cens_w_repeatmasker.smk
@@ -112,10 +112,8 @@ rule get_cen_corrections_lists:
         "logs/fix_cens_w_repeatmasker/get_complete_correct_cens_bed.log",
     shell:
         """
-        awk -v OFS="\\t" '{{
+        cat {input.statuses} | awk -v OFS="\\t" '{{
             ort=$3; is_partial=$4;
-
-            # Omit nucflag. Won't have column 5 and 6.
             if ("{params.omit_nucflag}" == "True") {{
                 split($1, split_name, ":")
                 is_misassembled=""
@@ -124,7 +122,6 @@ rule get_cen_corrections_lists:
                 is_misassembled=$6
                 name=$5
             }}
-            # Not partial and not misassembled. CHM13 chrs will be empty.
             if (is_partial == "false" && (is_misassembled == "good" || is_misassembled == "")) {{
                 if (ort == "fwd") {{
                     print name >> "{output.correct_cens_list}"
@@ -139,7 +136,7 @@ rule get_cen_corrections_lists:
             }} else {{
                 print name >> "{output.partial_misasm_cens_list}"
             }}
-        }}' {input.statuses} 2> {log}
+        }}' 2> {log}
         if [ ! -f {output.partial_misasm_cens_list} ]; then
             echo "No partial cens. Creating empty file." > {log}
             touch {output.partial_misasm_cens_list}

--- a/workflow/rules/fix_cens_w_repeatmasker.smk
+++ b/workflow/rules/fix_cens_w_repeatmasker.smk
@@ -1,10 +1,21 @@
-# Included workflow. Cannot be run separately outside of `repeatmasker.smk`.
+include: "common.smk"
+include: "utils.smk"
 
 
 rule check_cens_status:
     input:
-        rm_out=rules.extract_rm_out_by_chr.output.rm_out_by_chr,
-        rm_ref=rules.merge_control_repeatmasker_output.output,
+        rm_out=os.path.join(
+            config["repeatmasker"]["output_dir"],
+            "repeats",
+            "all",
+            "{chr}_cens.fa.out",
+        ),
+        rm_ref=os.path.join(
+            config["repeatmasker"]["output_dir"],
+            "repeats",
+            "ref",
+            "ref_ALR_regions.fa.out",
+        ),
     output:
         cens_status=os.path.join(
             config["repeatmasker"]["output_dir"], "status", "{chr}_cens_status.tsv"
@@ -37,9 +48,49 @@ rule check_cens_status:
         """
 
 
+rule join_cen_status_and_nucflag_status:
+    input:
+        nucflag_statuses=(
+            expand(
+                os.path.join(config["nucflag"]["output_dir"], "{sm}_cen_status.bed"),
+                sm=SAMPLE_NAMES,
+            )
+            if config.get("nucflag")
+            else []
+        ),
+        statuses=expand(rules.check_cens_status.output.cens_status, chr=CHROMOSOMES),
+    output:
+        all_statuses=os.path.join(
+            config["repeatmasker"]["output_dir"], "status", "cens_status_w_nucflag.tsv"
+        ),
+    params:
+        censtats_base_name_col=5,
+        nucflag_base_name_col=1,
+        # cs - censtats, nf - nucflag, both
+        # [cs:original_name, cs:new_name, cs:ort, cs:is_partial, both:abbreviated_name, nf:status]
+        output_format="1.1,1.2,1.3,1.4,0,2.2",
+    log:
+        "logs/fix_cens_w_repeatmasker/join_cen_status_and_nucflag_status.log",
+    shell:
+        """
+        join \
+        -1 {params.censtats_base_name_col} -2 {params.nucflag_base_name_col} \
+        -a 1 -a 2 \
+        -o {params.output_format} \
+        <(awk -v OFS="\\t" '{{ split($1, split_name, ":"); print $0, split_name[1]}}' {input.statuses} | \
+            sort -k {params.censtats_base_name_col}) \
+        <(cut -f {params.nucflag_base_name_col},4 {input.nucflag_statuses} | \
+            sort -k {params.nucflag_base_name_col}) > {output} 2> {log}
+        """
+
+
 rule get_cen_corrections_lists:
     input:
-        statuses=expand(rules.check_cens_status.output.cens_status, chr=CHROMOSOMES),
+        statuses=(
+            rules.join_cen_status_and_nucflag_status.output
+            if config.get("nucflag")
+            else expand(rules.check_cens_status.output.cens_status, chr=CHROMOSOMES)
+        ),
     output:
         correct_cens_list=os.path.join(
             config["repeatmasker"]["output_dir"],
@@ -52,33 +103,46 @@ rule get_cen_corrections_lists:
             "status",
             "all_reverse_cens.tsv",
         ),
-        partial_cens_list=os.path.join(
+        partial_misasm_cens_list=os.path.join(
             config["repeatmasker"]["output_dir"], "status", "all_partial_cens.list"
         ),
+    params:
+        omit_nucflag="nucflag" not in config,
     log:
         "logs/fix_cens_w_repeatmasker/get_complete_correct_cens_bed.log",
     shell:
         """
-        cat {input.statuses} | awk -v OFS="\t" '{{
-            split($1, names, ":");
-            if ($4 == "false") {{
-                if ($3 == "fwd") {{
-                    print names[1] >> "{output.correct_cens_list}"
+        awk -v OFS="\\t" '{{
+            ort=$3; is_partial=$4;
+
+            # Omit nucflag. Won't have column 5 and 6.
+            if ("{params.omit_nucflag}" == "True") {{
+                split($1, split_name, ":")
+                is_misassembled=""
+                name=split_name[1]
+            }} else {{
+                is_misassembled=$6
+                name=$5
+            }}
+            # Not partial and not misassembled. CHM13 chrs will be empty.
+            if (is_partial == "false" && (is_misassembled == "good" || is_misassembled == "")) {{
+                if (ort == "fwd") {{
+                    print name >> "{output.correct_cens_list}"
                 }} else {{
                     # 1. rc-chrX -> rc-rc-chrX (chrX)
                     # 2. rc-rc-chrX -> chrX
-                    new_name=names[1]
+                    new_name=name
                     gsub("chr", "rc-chr", new_name)
                     gsub("rc-rc-", "", new_name)
-                    print names[1],new_name >> "{output.reverse_cens_key}"
+                    print name,new_name >> "{output.reverse_cens_key}"
                 }}
             }} else {{
-                print names[1] >> "{output.partial_cens_list}"
+                print name >> "{output.partial_misasm_cens_list}"
             }}
-        }}' 2> {log}
-        if [ ! -f {output.partial_cens_list} ]; then
+        }}' {input.statuses} 2> {log}
+        if [ ! -f {output.partial_misasm_cens_list} ]; then
             echo "No partial cens. Creating empty file." > {log}
-            touch {output.partial_cens_list}
+            touch {output.partial_misasm_cens_list}
         fi
         if [ ! -f {output.reverse_cens_key} ]; then
             echo "No cens to reverse. Creating empty file." > {log}
@@ -90,7 +154,9 @@ rule get_cen_corrections_lists:
 rule get_complete_correct_cens_bed:
     input:
         script="workflow/scripts/filter_complete_cens_bed.py",
-        bed=rules.get_valid_regions_for_rm.output,
+        bed=os.path.join(
+            config["new_cens"]["output_dir"], "bed", "{sm}_ALR_regions.bed"
+        ),
         # Need lengths to determine coordinates for reversed contigs
         fai=os.path.join(
             config["concat_asm"]["output_dir"],
@@ -98,7 +164,7 @@ rule get_complete_correct_cens_bed:
             "{sm}_regions.renamed.reort.fa.fai",
         ),
         correct_cens_list=rules.get_cen_corrections_lists.output.correct_cens_list,
-        partial_cens_list=rules.get_cen_corrections_lists.output.partial_cens_list,
+        partial_misasm_cens_list=rules.get_cen_corrections_lists.output.partial_misasm_cens_list,
         reverse_cens_key=rules.get_cen_corrections_lists.output.reverse_cens_key,
     output:
         complete_correct_cens_bed=os.path.join(
@@ -116,7 +182,7 @@ rule get_complete_correct_cens_bed:
         -i {input.bed} \
         -l {input.fai} \
         -c {input.correct_cens_list} \
-        -p {input.partial_cens_list} \
+        -p {input.partial_misasm_cens_list} \
         -r {input.reverse_cens_key} > {output} 2> {log}
         """
 
@@ -246,9 +312,14 @@ rule get_reverse_cens_key_with_ctg_len:
 
 rule fix_cens_rm_out:
     input:
-        partial_cens_list=rules.get_cen_corrections_lists.output.partial_cens_list,
+        partial_misasm_cens_list=rules.get_cen_corrections_lists.output.partial_misasm_cens_list,
         reverse_cens_key_w_len=rules.get_reverse_cens_key_with_ctg_len.output,
-        rm_out=rules.extract_rm_out_by_chr.output,
+        rm_out=os.path.join(
+            config["repeatmasker"]["output_dir"],
+            "repeats",
+            "all",
+            "{chr}_cens.fa.out",
+        ),
     output:
         corrected_rm_out=os.path.join(
             config["repeatmasker"]["output_dir"],
@@ -262,7 +333,7 @@ rule fix_cens_rm_out:
         """
         # Write everything but the partials and reversed cens.
         grep -v -f \
-            <(grep "{wildcards.chr}[_:]" {input.partial_cens_list} | cat - <(grep "{wildcards.chr}[_:]" {input.reverse_cens_key_w_len} | cut -f 1)) \
+            <(grep "{wildcards.chr}[_:]" {input.partial_misasm_cens_list} | cat - <(grep "{wildcards.chr}[_:]" {input.reverse_cens_key_w_len} | cut -f 1)) \
             {input.rm_out} > {output} 2> {log}
 
         while IFS='' read -r line; do
@@ -296,35 +367,23 @@ rule fix_cens_rm_out:
         """
 
 
-rule plot_cens_from_rm_by_chr:
+use rule plot_rm_out as plot_cens_from_rm_by_chr with:
     input:
         script="workflow/scripts/repeatStructure_onlyRM.R",
         rm_out=rules.fix_cens_rm_out.output,
     output:
-        repeat_plot_by_chr=os.path.join(
+        repeat_plot=os.path.join(
             config["repeatmasker"]["output_dir"],
             "plot",
             "{chr}_cens.pdf",
         ),
     log:
         "logs/fix_cens_w_repeatmasker/plot_{chr}_cens_from_rm.log",
-    conda:
-        "../env/r.yaml"
-    shell:
-        """
-        Rscript {input.script} {input.rm_out} {output.repeat_plot_by_chr} 2> {log}
-        """
 
 
-use rule plot_cens_from_rm_by_chr as plot_cens_from_original_rm_by_chr with:
+rule fix_cens_w_repeatmasker_only:
     input:
-        script="workflow/scripts/repeatStructure_onlyRM.R",
-        rm_out=rules.extract_rm_out_by_chr.output,
-    output:
-        repeat_plot_by_chr=os.path.join(
-            config["repeatmasker"]["output_dir"],
-            "plot",
-            "{chr}_cens_original.pdf",
-        ),
-    log:
-        "logs/fix_cens_w_repeatmasker/plot_{chr}_cens_from_original_rm.log",
+        expand(rules.fix_ort_asm_final.output, sm=SAMPLE_NAMES),
+        expand(rules.extract_sm_complete_correct_cens.output, sm=SAMPLE_NAMES),
+        expand(rules.merge_all_complete_correct_cens_fa.output, sm=SAMPLE_NAMES),
+        expand(rules.plot_cens_from_rm_by_chr.output, chr=CHROMOSOMES),

--- a/workflow/rules/nucflag.smk
+++ b/workflow/rules/nucflag.smk
@@ -81,6 +81,7 @@ rule simplify_rm_overlay_bed:
     params:
         color_alr_alpha="#8B008B",
         color_other="gray",
+        color_none="yellow",
     conda:
         "../env/py.yaml"
     log:
@@ -89,6 +90,7 @@ rule simplify_rm_overlay_bed:
         """
         python {input.script} -i {input.bed} \
         --color_alr_alpha "{params.color_alr_alpha}" \
+        --color_none "{params.color_none}" \
         --color_other "{params.color_other}" > {output} 2> {log}
         """
 

--- a/workflow/rules/nucflag.smk
+++ b/workflow/rules/nucflag.smk
@@ -22,7 +22,6 @@ NUCFLAG_CFG = {
                 }
             ),
             "config": config["nucflag"]["config_nucflag"],
-            "ignore_bed": config["nucflag"]["ignore_regions"],
             "region_bed": os.path.join(
                 config["new_cens"]["output_dir"], "bed", f"{sm}_ALR_regions.bed"
             ),

--- a/workflow/rules/nucflag.smk
+++ b/workflow/rules/nucflag.smk
@@ -26,6 +26,14 @@ NUCFLAG_CFG = {
             "region_bed": os.path.join(
                 config["new_cens"]["output_dir"], "bed", f"{sm}_ALR_regions.bed"
             ),
+            "overlay_beds": [
+                os.path.join(
+                    config["repeatmasker"]["output_dir"],
+                    "bed",
+                    f"{sm}",
+                    f"{sm}_correct_ALR_regions.fa.reformatted.bed",
+                ),
+            ],
         }
         for sm in SAMPLE_NAMES
     ],

--- a/workflow/rules/nucflag.smk
+++ b/workflow/rules/nucflag.smk
@@ -1,6 +1,98 @@
 include: "common.smk"
 
 
+rule format_repeatmasker_to_overlay_bed:
+    input:
+        rm=os.path.join(
+            config["repeatmasker"]["output_dir"],
+            "repeats",
+            "{sm}",
+            "{sm}_correct_ALR_regions.fa.reformatted.out",
+        ),
+    output:
+        os.path.join(
+            config["nucflag"]["output_dir"],
+            "{sm}_correct_ALR_regions.rm.bed",
+        ),
+    log:
+        "logs/nucflag/format_repeatmasker_to_overlay_bed_{sm}.log",
+    params:
+        color_alr_alpha="#8B008B",
+    conda:
+        "../env/tools.yaml"
+    shell:
+        """
+        awk -v OFS="\\t" '{{
+            name=$5; start=$6; end=$7; rType=$10; rClass=$11;
+
+            # Find contig coordinates
+            match(name, "^(.+):", abbr_name);
+            match(name, ":(.+)-", ctg_start);
+            match(name, ".*-(.+)$", ctg_end);
+            new_name=abbr_name[1];
+            new_start=start+ctg_start[1];
+            new_end=end+ctg_start[1];
+
+            # Split repeat class and replace specific repeat types.
+            split(rClass, split_rClass, "/" );
+            new_rClass=split_rClass[1];
+            if (rClass == "Satellite/centr" || rClass == "Satellite") {{
+                new_rClass=rType
+            }}
+            switch (new_rClass) {{
+                case "SAR":
+                    new_rClass="HSat1A";
+                    break;
+                case "HSAT":
+                    new_rClass="HSat1B";
+                    break;
+                case "HSATII":
+                    new_rClass="HSat2";
+                    break;
+                case "(CATTC)n":
+                    new_rClass="HSat2";
+                    break;
+                case "(GAATG)n":
+                    new_rClass="HSat2";
+                    break;
+                default:
+                    break;
+            }}
+
+            # Set action for NucFlag
+            action="plot"
+            if (new_rClass == "ALR/Alpha") {{
+                action="plot:{params.color_alr_alpha}"
+            }}
+            print new_name, new_start, new_end, new_rClass, action
+        }}' {input.rm} > {output} 2> {log}
+        """
+
+
+rule simplify_rm_overlay_bed:
+    input:
+        script="workflow/scripts/simplify_rm_coords.py",
+        bed=rules.format_repeatmasker_to_overlay_bed.output,
+    output:
+        os.path.join(
+            config["nucflag"]["output_dir"],
+            "{sm}_correct_ALR_regions.rm.simple.bed",
+        ),
+    params:
+        color_alr_alpha="#8B008B",
+        color_other="gray",
+    conda:
+        "../env/py.yaml"
+    log:
+        "logs/nucflag/simplify_rm_overlay_bed_{sm}.log",
+    shell:
+        """
+        python {input.script} -i {input.bed} \
+        --color_alr_alpha "{params.color_alr_alpha}" \
+        --color_other "{params.color_other}" > {output} 2> {log}
+        """
+
+
 NUCFLAG_CFG = {
     "samples": [
         {
@@ -26,12 +118,10 @@ NUCFLAG_CFG = {
                 config["new_cens"]["output_dir"], "bed", f"{sm}_ALR_regions.bed"
             ),
             "overlay_beds": [
-                os.path.join(
-                    config["repeatmasker"]["output_dir"],
-                    "bed",
-                    f"{sm}",
-                    f"{sm}_correct_ALR_regions.fa.reformatted.bed",
-                ),
+                # Original repeatmasker options
+                str(rules.format_repeatmasker_to_overlay_bed.output),
+                # Just ALR
+                str(rules.simplify_rm_overlay_bed.output),
             ],
         }
         for sm in SAMPLE_NAMES
@@ -52,4 +142,6 @@ use rule * from NucFlag
 
 rule nucflag_only:
     input:
+        expand(rules.format_repeatmasker_to_overlay_bed.output, sm=SAMPLE_NAMES),
+        expand(rules.simplify_rm_overlay_bed.output, sm=SAMPLE_NAMES),
         expand(rules.nucflag.input, sm=SAMPLE_NAMES),

--- a/workflow/rules/nucflag.smk
+++ b/workflow/rules/nucflag.smk
@@ -78,20 +78,13 @@ rule simplify_rm_overlay_bed:
             config["nucflag"]["output_dir"],
             "{sm}_correct_ALR_regions.rm.simple.bed",
         ),
-    params:
-        color_alr_alpha="#8B008B",
-        color_other="gray",
-        color_none="yellow",
     conda:
         "../env/py.yaml"
     log:
         "logs/nucflag/simplify_rm_overlay_bed_{sm}.log",
     shell:
         """
-        python {input.script} -i {input.bed} \
-        --color_alr_alpha "{params.color_alr_alpha}" \
-        --color_none "{params.color_none}" \
-        --color_other "{params.color_other}" > {output} 2> {log}
+        python {input.script} -i {input.bed} > {output} 2> {log}
         """
 
 
@@ -119,11 +112,11 @@ NUCFLAG_CFG = {
             "region_bed": os.path.join(
                 config["new_cens"]["output_dir"], "bed", f"{sm}_ALR_regions.bed"
             ),
+            # Ignore regions.
+            "ignore_bed": str(rules.simplify_rm_overlay_bed.output),
             "overlay_beds": [
                 # Original repeatmasker options
                 str(rules.format_repeatmasker_to_overlay_bed.output),
-                # Just ALR
-                str(rules.simplify_rm_overlay_bed.output),
             ],
         }
         for sm in SAMPLE_NAMES
@@ -134,7 +127,9 @@ NUCFLAG_CFG = {
 
 module NucFlag:
     snakefile:
-        github("logsdon-lab/Snakemake-NucFlag", path="workflow/Snakefile", tag="v0.1.0")
+        github(
+            "logsdon-lab/Snakemake-NucFlag", path="workflow/Snakefile", branch="main"
+        )
     config:
         NUCFLAG_CFG
 

--- a/workflow/rules/plot_cens_structure.smk
+++ b/workflow/rules/plot_cens_structure.smk
@@ -19,12 +19,14 @@ rule plot_cens_structure:
         plot=os.path.join(
             config["plot_hor_stv"]["output_dir"],
             "plots",
+            "hor",
             "all_cens_{chr}_{mer_order}.png",
         ),
         cen_plot_dir=directory(
             os.path.join(
                 config["plot_hor_stv"]["output_dir"],
                 "plots",
+                "hor",
                 "{chr}_{mer_order}",
             )
         ),

--- a/workflow/rules/plot_hor_stv.smk
+++ b/workflow/rules/plot_hor_stv.smk
@@ -87,6 +87,7 @@ rule plot_stv_with_order:
         hor_array_plot=os.path.join(
             config["plot_hor_stv"]["output_dir"],
             "plots",
+            "hor",
             "{chr}_{mer_order}ontop.png",
         ),
     log:

--- a/workflow/rules/plot_repeatmasker_sat_annot.smk
+++ b/workflow/rules/plot_repeatmasker_sat_annot.smk
@@ -130,6 +130,7 @@ rule plot_satellite_annotations:
         chr_plot=os.path.join(
             config["plot_hor_stv"]["output_dir"],
             "plots",
+            "satellite",
             "all_cens_{chr}.annotation.png",
         ),
     log:

--- a/workflow/rules/utils.smk
+++ b/workflow/rules/utils.smk
@@ -21,3 +21,19 @@ rule extract_and_index_fa:
             touch {output.idx}
         fi
         """
+
+
+rule plot_rm_out:
+    input:
+        script="workflow/scripts/repeatStructure_onlyRM.R",
+        rm_out="",
+    output:
+        repeat_plot="",
+    log:
+        "logs/plot_rm_out.log",
+    conda:
+        "../env/r.yaml"
+    shell:
+        """
+        Rscript {input.script} {input.rm_out} {output.repeat_plot} 2> {log}
+        """

--- a/workflow/scripts/filter_complete_cens_bed.py
+++ b/workflow/scripts/filter_complete_cens_bed.py
@@ -3,7 +3,7 @@ import argparse
 import polars as pl
 
 
-INFILE_COLS = ("name", "start", "end", "length", "status")
+INFILE_COLS = ("name", "start", "end", "length")
 
 
 def main():
@@ -78,7 +78,7 @@ def main():
             .then(pl.col("length_right") - pl.col("start"))
             .otherwise(pl.col("end")),
         )
-        .select("new_name", "new_start", "new_end", "length", "status")
+        .select("new_name", "new_start", "new_end", "length")
     )
     df_final_bed.write_csv(args.outfile, include_header=False, separator="\t")
 

--- a/workflow/scripts/simplify_rm_coords.py
+++ b/workflow/scripts/simplify_rm_coords.py
@@ -9,6 +9,7 @@ def main():
     ap.add_argument("-o", "--output", default=sys.stdout, type=argparse.FileType("wt"))
     ap.add_argument("--color_alr_alpha", type=str, default="#8B008B")
     ap.add_argument("--color_other", type=str, default="gray")
+    ap.add_argument("--color_none", type=str, default="yellow")
 
     args = ap.parse_args()
     df = pl.read_csv(
@@ -18,44 +19,67 @@ def main():
         separator="\t",
     )
 
-    df_group_merged = pl.concat(
-        df_grp.with_columns(
-            pl.when(pl.col("rtype") == "ALR/Alpha")
-            .then(pl.col("rtype"))
-            .otherwise(pl.lit("Other"))
-        )
-        .with_columns(
-            rle_id=pl.col("rtype").rle_id(),
-            # Set color for other and plot.
-            action=(
-                pl.when(pl.col("rtype") == "Other")
-                .then(pl.lit(f"plot:{args.color_other},ignore:absolute"))
-                .otherwise(pl.lit(f"plot:{args.color_alr_alpha}"))
-            ),
-        )
-        .group_by(["rle_id"])
-        .agg(
-            pl.col("name").first(),
-            pl.col("start").min(),
-            pl.col("stop").max(),
-            pl.col("rtype").first(),
-            pl.col("action").first(),
-        )
-        .with_columns(len=pl.col("stop") - pl.col("start"))
-        .sort(by="rle_id")
-        # Handle edge cases where small ignored repeats between ALR. Allow misassemblies.
-        .with_columns(
-            pl.when(
-                (pl.col("rtype").shift(1) == "ALR/Alpha")
-                & (pl.col("rtype").shift(-1) == "ALR/Alpha")
-                & (pl.col("len") < 10_000)
+    dfs = []
+    for name, df_grp in df.group_by(["name"]):
+        name = name[0]
+        df_grp = (
+            df_grp.with_columns(
+                pl.when(pl.col("rtype") == "ALR/Alpha")
+                .then(pl.col("rtype"))
+                .otherwise(pl.lit("Other"))
             )
-            .then(pl.col("action").str.replace(",ignore:absolute", "", literal=True))
-            .otherwise(pl.col("action"))
+            .with_columns(
+                rle_id=pl.col("rtype").rle_id(),
+                # Set color for other and plot.
+                action=(
+                    pl.when(pl.col("rtype") == "Other")
+                    .then(pl.lit(f"plot:{args.color_other},ignore:absolute"))
+                    .otherwise(pl.lit(f"plot:{args.color_alr_alpha}"))
+                ),
+            )
+            .group_by(["rle_id"])
+            .agg(
+                pl.col("name").first(),
+                pl.col("start").min(),
+                pl.col("stop").max(),
+                pl.col("rtype").first(),
+                pl.col("action").first(),
+            )
+            .with_columns(len=pl.col("stop") - pl.col("start"))
+            .sort(by="rle_id")
+            # Handle edge cases where small ignored repeats between ALR. Allow misassemblies.
+            .with_columns(
+                pl.when(
+                    (pl.col("rtype").shift(1) == "ALR/Alpha")
+                    & (pl.col("rtype").shift(-1) == "ALR/Alpha")
+                    & (pl.col("len") < 10_000)
+                )
+                .then(
+                    pl.col("action").str.replace(",ignore:absolute", "", literal=True)
+                )
+                .otherwise(pl.col("action"))
+            )
+            .drop("rle_id", "len")
         )
-        .drop("rle_id", "len")
-        for _, df_grp in df.group_by(["name"])
-    )
+        df_no_annotation = (
+            df_grp.with_columns(diff=pl.col("start").shift(-1) - pl.col("stop"))
+            .select(
+                name=pl.lit(name),
+                # Any set of rows where diff from first and second row is greater than 1 bp.
+                start=pl.when(pl.col("diff") > 1)
+                .then(pl.col("stop") + 1)
+                .otherwise(None),
+                stop=pl.when(pl.col("diff") > 1)
+                .then(pl.col("start").shift(-1) - 1)
+                .otherwise(None),
+                rtype=pl.lit("None"),
+                action=pl.lit("plot:yellow"),
+            )
+            .drop_nulls()
+        )
+        dfs.append(pl.concat([df_grp, df_no_annotation]).sort(by="start"))
+
+    df_group_merged = pl.concat(dfs)
     df_group_merged.write_csv(args.output, separator="\t", include_header=False)
 
 

--- a/workflow/scripts/simplify_rm_coords.py
+++ b/workflow/scripts/simplify_rm_coords.py
@@ -1,0 +1,63 @@
+import sys
+import argparse
+import polars as pl
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-i", "--input", default=sys.stdin, type=argparse.FileType("rb"))
+    ap.add_argument("-o", "--output", default=sys.stdout, type=argparse.FileType("wt"))
+    ap.add_argument("--color_alr_alpha", type=str, default="#8B008B")
+    ap.add_argument("--color_other", type=str, default="gray")
+
+    args = ap.parse_args()
+    df = pl.read_csv(
+        args.input,
+        new_columns=["name", "start", "stop", "rtype", "action"],
+        has_header=False,
+        separator="\t",
+    )
+
+    df_group_merged = pl.concat(
+        df_grp.with_columns(
+            pl.when(pl.col("rtype") == "ALR/Alpha")
+            .then(pl.col("rtype"))
+            .otherwise(pl.lit("Other"))
+        )
+        .with_columns(
+            rle_id=pl.col("rtype").rle_id(),
+            # Set color for other and plot.
+            action=(
+                pl.when(pl.col("rtype") == "Other")
+                .then(pl.lit(f"plot:{args.color_other},ignore:absolute"))
+                .otherwise(pl.lit(f"plot:{args.color_alr_alpha}"))
+            ),
+        )
+        .group_by(["rle_id"])
+        .agg(
+            pl.col("name").first(),
+            pl.col("start").min(),
+            pl.col("stop").max(),
+            pl.col("rtype").first(),
+            pl.col("action").first(),
+        )
+        .with_columns(len=pl.col("stop") - pl.col("start"))
+        .sort(by="rle_id")
+        # Handle edge cases where small ignored repeats between ALR. Allow misassemblies.
+        .with_columns(
+            pl.when(
+                (pl.col("rtype").shift(1) == "ALR/Alpha")
+                & (pl.col("rtype").shift(-1) == "ALR/Alpha")
+                & (pl.col("len") < 10_000)
+            )
+            .then(pl.col("action").str.replace(",ignore:absolute", "", literal=True))
+            .otherwise(pl.col("action"))
+        )
+        .drop("rle_id", "len")
+        for _, df_grp in df.group_by(["name"])
+    )
+    df_group_merged.write_csv(args.output, separator="\t", include_header=False)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
* Added `config_censtats_status` optional config file to specify thresholds for `censtats status`.
* Added `RepeatMasker` annotations to nucflag plots.
* Changed `nucflag` workflow to be after `RepeatMasker`.
* Changed `nucflag` to only consider misassemblies in ALR/Alpha repeats.
* Changed fix_cens_w_repeatmasker workflow to run independently.
* Removed `nucflag_ignore.bed` as it caused small or partial centromeres to be missed.
* Fixed closely overlapping ALR and ignored regions omitting misassemblies.
* Fixed edge-case for `censtats status` and chrX.
