### PR TITLE
bugfix: Multiple HOR lengths for reference

### DIFF
--- a/workflow/rules/calculate_hor_length.smk
+++ b/workflow/rules/calculate_hor_length.smk
@@ -20,11 +20,12 @@ rule calculate_as_hor_length:
         bp_jump_thr=100_000,
         arr_len_thr=30_000,
     shell:
+        # grep to remove chm13.
         """
-        ( censtats length \
+        {{ censtats length \
         --input {input.fmt_hmmer_output} \
         --bp_jump_thr {params.bp_jump_thr} \
-        --arr_len_thr {params.arr_len_thr} || true ) > {output} 2> {log}
+        --arr_len_thr {params.arr_len_thr} | grep -v ^chr ;}} > {output} 2> {log}
         """
 
 

--- a/workflow/rules/plot_hor_stv.smk
+++ b/workflow/rules/plot_hor_stv.smk
@@ -9,14 +9,15 @@ rule get_live_hor:
         humas_hmmer_out=rules.cens_filter_hmm_res_overlaps_as_hor.output,
     output:
         renamed_bed=os.path.join(
-            config["humas_hmmer"]["output_dir"],
+            config["plot_hor_stv"]["output_dir"],
             "bed",
-            "results_{chr}_stv" "{fname}_renamed.bed",
+            "{chr}",
+            "{fname}_renamed.bed",
         ),
         live_hor_bed=os.path.join(
-            config["humas_hmmer"]["output_dir"],
+            config["plot_hor_stv"]["output_dir"],
             "bed",
-            "results_{chr}_stv",
+            "{chr}",
             "{fname}_liveHORs.bed",
         ),
     params:
@@ -46,15 +47,15 @@ rule filter_as_hor_stv_bed:
         renamed_bed=rules.get_live_hor.output.renamed_bed,
     output:
         stv_row_bed=os.path.join(
-            config["humas_hmmer"]["output_dir"],
+            config["plot_hor_stv"]["output_dir"],
             "bed",
-            "results_{chr}_stv",
+            "{chr}",
             "{fname}_stv_row.bed",
         ),
         as_hor_stv_row_bed=os.path.join(
-            config["humas_hmmer"]["output_dir"],
+            config["plot_hor_stv"]["output_dir"],
             "bed",
-            "results_{chr}_stv",
+            "{chr}",
             "AS-HOR_{fname}_stv_row.bed",
         ),
     log:


### PR DESCRIPTION
* Fixed including CHM13 lengths multiple times.
* Fixed missing comma in plot_hor_stv workflow causing path to be concatenated.
* Moved hor_stv output to plot_hor_stv output directory and renamed so simpler.