### PR TITLE
bugfix: ModDotPlot version

### DIFF
--- a/workflow/envs/py.yaml
+++ b/workflow/envs/py.yaml
@@ -11,4 +11,4 @@ dependencies:
     - editdistance
     - scipy
     - censtats==0.0.5
-    - git+https://github.com/marbl/ModDotPlot.git@main
+    - git+https://github.com/marbl/ModDotPlot.git@v0.8.4


### PR DESCRIPTION
* Fixed ModDotPlot version to v0.8.4 fixing dependency conflict.