### PR TITLE
bugfix: Better mapping and usage

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -30,7 +30,7 @@ samples:
 concat_asm:
   # Expects {input_dir}/{sm}/*.gz
   input_dir: "data/assemblies"
-  output_dir: "data/assemblies/combined"
+  output_dir: "results/assemblies/combined"
   mem: 20GB
 
 align_asm_to_ref:
@@ -41,8 +41,8 @@ align_asm_to_ref:
 
 extract_ref_hor_arrays:
   output_dir: "results/ref_hor_arrays"
-  # Add bp to extend edges of HOR array for alignment.
-  added_bases: 0
+  # Add bp to extend edges of HOR array for alignment. In addition to default 500kbp.
+  added_bases: 500_000
 
 ident_cen_ctgs:
   comb_assemblies_dir: "data/assemblies/combined"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -35,7 +35,6 @@ include: "rules/humas_hmmer.smk"
 rule extract_cens_only:
     input:
         rules.extract_ref_hor_arrays_all.input,
-        rules.concat_asm_all.input,
         rules.align_asm_ref_all.input,
         rules.ident_cen_ctgs_all.input,
 

--- a/workflow/rules/humas_hmmer.smk
+++ b/workflow/rules/humas_hmmer.smk
@@ -97,7 +97,7 @@ def humas_hmmer_outputs(wc):
     }
 
 
-rule run_humas_hmmer_for_anvil:
+checkpoint run_humas_hmmer_for_anvil:
     input:
         unpack(humas_hmmer_outputs),
     output:

--- a/workflow/rules/plot_hor_stv.smk
+++ b/workflow/rules/plot_hor_stv.smk
@@ -74,12 +74,17 @@ def as_hor_bedfiles(wc):
     fnames, chrs = extract_fa_fnames_and_chr(
         config["humas_hmmer"]["input_dir"], filter_chr=str(wc.chr)
     )
-    return expand(rules.filter_as_hor_stv_bed.output, zip, fname=fnames, chr=chrs)
+    _ = checkpoints.run_humas_hmmer_for_anvil.get(**wc).output
+    return dict(
+        stv_bed_filtered=expand(
+            rules.filter_as_hor_stv_bed.output, zip, fname=fnames, chr=chrs
+        )
+    )
 
 
-rule aggregate_format_all_stv_row:
+checkpoint aggregate_format_all_stv_row:
     input:
-        as_hor_bedfiles,
+        unpack(as_hor_bedfiles),
     output:
         os.path.join(
             config["plot_hor_stv"]["output_dir"], "bed", "{chr}_AS-HOR_stv_row.all.bed"


### PR DESCRIPTION
* Changed default output dir for concatenated assemblies.
* Changed the default number of bases from the reference alpha-satellite HOR array to prevent mismappings.
* Removed concat_asm rule being necessary to prevent unnecessary reruns.
* Fixed bug in checkpoint order causing dependent rules not to be run.
    * See #74