### PR TITLE
chore: Snakemake-NucFlag v0.2.1.

### DIFF
--- a/config/nucflag.toml
+++ b/config/nucflag.toml
@@ -8,29 +8,29 @@ thr_min_valley_width = 5
 # Valleys with height above this threshold are considered misjoins.
 thr_misjoin_valley = 0.8
 
-# Peaks with height above this threshold are considered collapses w/no variants.
-thr_collapse_peak = 3.0
+# Peaks with height above this threshold are considered collapses.
+thr_collapse_peak = 2.5
 
 # Group consecutive positions allowing a maximum gap of x.
 # Larger value groups more positions.
-valley_group_distance = 1
+valley_group_distance = 5_000
 
-peak_group_distance = 1
+peak_group_distance = 5_000
 
 [second]
 # Percent threshold of most freq base to allow second most freq base
 # 30 * 0.1 = 3 so above 3 is allowed.
-thr_min_perc_first = 0.1
+thr_min_perc_first = 0.05
 
 # Group consecutive positions allowing a maximum gap of x.
 # Larger value groups more positions.
-group_distance = 10_000
+group_distance = 30_000
 
 # Min group size.
 thr_min_group_size = 5
 
 # Regions with a het ratio below this are hets. Otherwise, considered an error.
-thr_het_ratio = 0.25
+thr_het_ratio = 0.2
 
 [gaps]
 thr_max_allowed_gap_size = 0

--- a/workflow/rules/nucflag.smk
+++ b/workflow/rules/nucflag.smk
@@ -128,7 +128,7 @@ NUCFLAG_CFG = {
 module NucFlag:
     snakefile:
         github(
-            "logsdon-lab/Snakemake-NucFlag", path="workflow/Snakefile", tag="v0.2.0"
+            "logsdon-lab/Snakemake-NucFlag", path="workflow/Snakefile", tag="v0.2.1"
         )
     config:
         NUCFLAG_CFG


### PR DESCRIPTION
* Bump Snakemake-NucFlag version to v0.2.1.
* Updated default parameters.