### PR TITLE
chore: update nucflag

### DIFF
--- a/workflow/rules/nucflag.smk
+++ b/workflow/rules/nucflag.smk
@@ -128,7 +128,7 @@ NUCFLAG_CFG = {
 module NucFlag:
     snakefile:
         github(
-            "logsdon-lab/Snakemake-NucFlag", path="workflow/Snakefile", tag="v0.2.1"
+            "logsdon-lab/Snakemake-NucFlag", path="workflow/Snakefile", tag="v0.2.2"
         )
     config:
         NUCFLAG_CFG


### PR DESCRIPTION
Bump to `Snakemake-NucFlag` to `v0.2.2` which does not have an explicit `nucflag` version.
* Will switch to more strict versioning as `nucflag` becomes more stable.