### PR TITLE
feat: minimap2 lr:hqae ONT alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ venv/
 temp*/
 exp/
 Dockerfile
+.cache/
 
 RM_*
 .RepeatMaskerCache/

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -116,6 +116,10 @@ moddotplot:
   window: 5000
 
 cdr_finder:
+  # Either minimap2 (-x lr:hqae) or winnowmap (-x map-ont)
+  aligner: minimap2
+  # Default: -s 4000 and -I 10G
+  aligner_added_opts: ""
   # Expects sample subdir in input_dir.
   # Uses find and file pattern to merge bam.
   input_bam_dir: "data/ont"

--- a/workflow/envs/minimap2.yaml
+++ b/workflow/envs/minimap2.yaml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - winnowmap==2.03
+  - minimap2==2.28

--- a/workflow/rules/cdr_finder.smk
+++ b/workflow/rules/cdr_finder.smk
@@ -17,14 +17,14 @@ ADDED_ALIGNER_OPTS = config["cdr_finder"].get("aligner_added_opts", "")
 ALL_ALIGNER_SETTINGS = {
     "minimap2": {
         "preset": "lr:hqae",
-        "split_idx_num_base": "10G",
+        "split_idx_num_base": "-I 10G",
         "min_peak_dp_aln_score": "-s 4000",
         "additional": ADDED_ALIGNER_OPTS,
     },
     # https://www.biorxiv.org/content/10.1101/2024.11.01.621587v1
     "winnowmap": {
         "preset": "map-ont",
-        "split_idx_num_base": "10G",
+        "split_idx_num_base": "-I 10G",
         "min_peak_dp_aln_score": "-s 4000",
         "additional": "-W {input.kmer_cnts} " + ADDED_ALIGNER_OPTS,
     },

--- a/workflow/rules/cdr_finder.smk
+++ b/workflow/rules/cdr_finder.smk
@@ -47,14 +47,13 @@ rule merge_methyl_bam_to_fq:
     output:
         temp(
             os.path.join(
-                config["cdr_finder"]["output_dir"], "aln", "{sm}_methyl.fq.gz"
+                config["cdr_finder"]["output_dir"], "aln", "{sm}_methyl.fq"
             )
         ),
     params:
         file_pattern=config["cdr_finder"]["file_pattern"],
     resources:
         mem="16G",
-        sort_mem="8G",
     threads: config["cdr_finder"]["aln_threads"]
     log:
         "logs/cdr_finder/merge_methyl_bam_{sm}.log",
@@ -65,8 +64,7 @@ rule merge_methyl_bam_to_fq:
     shell:
         """
         {{ samtools merge -@ {threads} - $(find {input} -regex {params.file_pattern}) | \
-        samtools bam2fq -T "*" -@ {threads} - | \
-        bgzip ;}} > {output} 2> {log}
+        samtools bam2fq -T "*" -@ {threads} - ;}} > {output} 2> {log}
         """
 
 

--- a/workflow/rules/moddotplot.smk
+++ b/workflow/rules/moddotplot.smk
@@ -169,7 +169,10 @@ def moddotplot_outputs(wc):
             filter_chr=wc.chr,
         )
     else:
-        fnames, chrs = extract_fnames_and_chr(os.path.join(INPUT_FA_DIR, "{fname}.fa"))
+        fnames, chrs = extract_fnames_and_chr(
+            os.path.join(INPUT_FA_DIR, "{fname}.fa"),
+            filter_chr=wc.chr,
+        )
 
     return dict(
         moddotplot=expand(rules.run_moddotplot.output, zip, chr=chrs, fname=fnames),

--- a/workflow/rules/moddotplot.smk
+++ b/workflow/rules/moddotplot.smk
@@ -206,10 +206,6 @@ rule _force_moddotplot_env_inclusion:
 
 rule moddotplot_only:
     input:
-        (
-            expand(rules.moddotplot_all.output, chr=CHROMOSOMES)
-            if config["moddotplot"].get("input_dir") is None
-            else rules.moddotplot_all.input
-        ),
+        expand(rules.moddotplot_all.output, chr=CHROMOSOMES),
         rules._force_moddotplot_env_inclusion.output if IS_CONTAINERIZE_CMD else [],
     default_target: True

--- a/workflow/rules/moddotplot.smk
+++ b/workflow/rules/moddotplot.smk
@@ -62,9 +62,9 @@ rule filter_annotations_moddotplot:
             "all_cens.annotation.bed",
         ),
         all_cdr_bed=rules.merge_cdr_beds.output if config.get("cdr_finder") else [],
-        all_binned_methyl_bed=rules.merge_binned_methyl_beds.output
-        if config.get("cdr_finder")
-        else [],
+        all_binned_methyl_bed=(
+            rules.merge_binned_methyl_beds.output if config.get("cdr_finder") else []
+        ),
     output:
         sat_annot_bed=temp(
             os.path.join(OUTPUT_MODDOTPLOT_DIR, "{chr}_{fname}_sat_annot.bed")

--- a/workflow/rules/nucflag.smk
+++ b/workflow/rules/nucflag.smk
@@ -127,9 +127,7 @@ NUCFLAG_CFG = {
 
 module NucFlag:
     snakefile:
-        github(
-            "logsdon-lab/Snakemake-NucFlag", path="workflow/Snakefile", tag="v0.2.2"
-        )
+        github("logsdon-lab/Snakemake-NucFlag", path="workflow/Snakefile", tag="v0.2.2")
     config:
         NUCFLAG_CFG
 

--- a/workflow/scripts/r_utils/repeats.R
+++ b/workflow/scripts/r_utils/repeats.R
@@ -1,8 +1,8 @@
 get_humas_hmmer_stv_annot_colors <- function() {
   myColors <- c(
-    "#A8275C", "#9AC78A", "#A53D63", "#3997C6", "#29A3CE", "#5EB2A7", "#38A49B", "#45B4CE", "#A53D63", "#AA1B63", "#3F66A0",
-    "#D66C54", "#BFDD97", "#C0D875", "#E5E57A", "#B75361", "#F9E193", "#C6625D", "#E5D1A1", "#A1B5E5", "#9F68A5", "#81B25B",
-    "#F4DC78", "#7EC0B3", "#A8275C", "#8CC49F", "#893F89", "#6565AA"
+    "#A8275C", "#9AC78A", "#CC8FC1", "#3997C6", "#8882C4", "#8ABDD6", "#096858", "#45B4CE", "#AFA7D8", "#A874B5", "#3F66A0",
+    "#D66C54", "#BFDD97", "#AF5D87", "#E5E57A", "#ED975D", "#F9E193", "#93430C", "#E5D1A1", "#A1B5E5", "#9F68A5", "#81B25B",
+    "#F4DC78", "#7EC0B3", "#B23F73", "#8CC49F", "#893F89", "#6565AA"
   )
   names(myColors) <- levels(as.factor(c(
     "1", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
@@ -269,7 +269,7 @@ read_one_humas_hmmer_input <- function(
   df_samples <- switch(chr_name,
     "chr10" = subset(df_samples, as.numeric(mer) >= 5),
     "chr20" = subset(df_samples, as.numeric(mer) >= 5),
-    "chrY" = subset(df_samples, as.numeric(mer) >= 30),
+    "chrY" = subset(df_samples, as.numeric(mer) >= 20),
     "chr17" = subset(df_samples, as.numeric(mer) >= 4),
     df_samples
   )


### PR DESCRIPTION
* Added option to use minimap2 and the lr:hqae preset to map ONT reads for CDR-Finder.
* Changed stv colors for visibility.
* Fixed incorrect output for moddotplot.
* Removed bgzip for merged methyl bam.