### PR TITLE
bugfix: wrong rule input and unnecessary reruns

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -37,8 +37,8 @@ concat_asm:
 
 align_asm_to_ref:
   # reference: "data/reference/T2T-CHM13v2.fasta.gz"
-  threads: 4
-  mem: 60GB
+  threads: 8
+  mem: 120GB
 
 extract_ref_hor_arrays:
   # Add bp to extend edges of HOR array for alignment. In addition to default 500kbp.

--- a/workflow/profiles/lpc/config.yaml
+++ b/workflow/profiles/lpc/config.yaml
@@ -5,7 +5,7 @@ default-resources:
   mem: 8GB
   mem_mb: 8000
   # Specific for Logsdon Lab
-  lsf_queue: epistasis_normal
+  lsf_queue: epistasis_long
   lsf_project: default
   # Hard memory limit that prevents out of memory for jobs.
   # LSF doesn't respect solely just rusage.
@@ -15,3 +15,4 @@ rerun-incomplete: True
 show-failed-logs: True
 rerun-triggers: mtime
 restart-times: 1
+latency-wait: 60

--- a/workflow/rules/1-concat_asm.smk
+++ b/workflow/rules/1-concat_asm.smk
@@ -22,7 +22,7 @@ rule concat_asm:
     resources:
         mem=config["concat_asm"].get("mem", "4GB"),
     log:
-        join(CONCAT_ASM_BMKDIR, "concat_asm_{sm}.log"),
+        join(CONCAT_ASM_LOGDIR, "concat_asm_{sm}.log"),
     conda:
         "../envs/tools.yaml"
     shell:

--- a/workflow/rules/5-dna_brnn.smk
+++ b/workflow/rules/5-dna_brnn.smk
@@ -157,7 +157,7 @@ def dna_brnn_output(wc):
     )
 
 
-rule aggregate_dnabrnn_alr_regions_by_chr:
+rule aggregate_dnabrnn_alr_regions_by_sample:
     input:
         sample_cens=dna_brnn_output,
     output:
@@ -176,10 +176,10 @@ rule aggregate_dnabrnn_alr_regions_by_chr:
         """
 
 
-rule extract_alr_region_sample_by_chr:
+rule extract_alr_regions_by_sample:
     input:
         fa=rules.concat_asm.output.fa,
-        bed=rules.aggregate_dnabrnn_alr_regions_by_chr.output,
+        bed=rules.aggregate_dnabrnn_alr_regions_by_sample.output,
     output:
         seq=temp(
             join(
@@ -201,6 +201,8 @@ rule extract_alr_region_sample_by_chr:
         **params_shell_extract_and_index_fa,
     log:
         join(DNA_BRNN_LOGDIR, "extract_alr_region_{sm}.log"),
+    conda:
+        "../envs/tools.yaml"
     shell:
         shell_extract_and_index_fa
 
@@ -208,7 +210,7 @@ rule extract_alr_region_sample_by_chr:
 rule dna_brnn_all:
     input:
         expand(
-            rules.aggregate_dnabrnn_alr_regions_by_chr.output,
+            rules.aggregate_dnabrnn_alr_regions_by_sample.output,
             sm=SAMPLE_NAMES,
         ),
     default_target: True

--- a/workflow/rules/5-dna_brnn.smk
+++ b/workflow/rules/5-dna_brnn.smk
@@ -179,23 +179,19 @@ rule aggregate_dnabrnn_alr_regions_by_sample:
 rule extract_alr_regions_by_sample:
     input:
         fa=rules.concat_asm.output.fa,
-        bed=rules.aggregate_dnabrnn_alr_regions_by_sample.output,
+        bed=ancient(rules.aggregate_dnabrnn_alr_regions_by_sample.output),
     output:
-        seq=temp(
-            join(
-                DNA_BRNN_OUTDIR,
-                "seq",
-                "interm",
-                "{sm}_contigs.ALR.fa",
-            )
+        seq=join(
+            DNA_BRNN_OUTDIR,
+            "seq",
+            "interm",
+            "{sm}_contigs.ALR.fa",
         ),
-        idx=temp(
-            join(
-                DNA_BRNN_OUTDIR,
-                "seq",
-                "interm",
-                "{sm}_contigs.ALR.fa.fai",
-            )
+        idx=join(
+            DNA_BRNN_OUTDIR,
+            "seq",
+            "interm",
+            "{sm}_contigs.ALR.fa.fai",
         ),
     params:
         **params_shell_extract_and_index_fa,
@@ -210,7 +206,7 @@ rule extract_alr_regions_by_sample:
 rule dna_brnn_all:
     input:
         expand(
-            rules.aggregate_dnabrnn_alr_regions_by_sample.output,
+            rules.extract_alr_regions_by_sample.output,
             sm=SAMPLE_NAMES,
         ),
     default_target: True

--- a/workflow/rules/6-repeatmasker.smk
+++ b/workflow/rules/6-repeatmasker.smk
@@ -193,7 +193,7 @@ rule format_repeatmasker_output:
 # |1259|28.4|7.4|5.3|GM18989_chr1_hap1-0000003:9717731-15372230|8|560|(5653940)|+|Charlie2b|DNA/hAT-Charlie|120|683|(2099)|1|
 rule merge_repeatmasker_output:
     input:
-        expand(rules.format_repeatmasker_output.output, sm=SAMPLE_NAMES),
+        ancient(expand(rules.format_repeatmasker_output.output, sm=SAMPLE_NAMES)),
     output:
         temp(
             join(
@@ -326,6 +326,6 @@ rule plot_og_rm_bed_by_chr:
 
 rule repeatmasker_all:
     input:
-        expand(rules.format_repeatmasker_output.output, sm=SAMPLE_NAMES),
+        rules.merge_repeatmasker_output.output,
         expand(rules.plot_og_rm_bed_by_chr.output, chr=CHROMOSOMES),
     default_target: True

--- a/workflow/rules/6-repeatmasker.smk
+++ b/workflow/rules/6-repeatmasker.smk
@@ -326,6 +326,5 @@ rule plot_og_rm_bed_by_chr:
 
 rule repeatmasker_all:
     input:
-        rules.merge_repeatmasker_output.output,
         expand(rules.plot_og_rm_bed_by_chr.output, chr=CHROMOSOMES),
     default_target: True

--- a/workflow/rules/6-repeatmasker.smk
+++ b/workflow/rules/6-repeatmasker.smk
@@ -12,7 +12,7 @@ RM_BMKDIR = join(BMK_DIR, "6-repeatmasker")
 
 checkpoint split_cens_for_rm:
     input:
-        fa=rules.extract_alr_region_sample_by_chr.output.seq,
+        fa=rules.extract_alr_regions_by_sample.output.seq,
         # [old_name, new_name, coords, sm, chr, is_reversed]
         rename_key=rules.map_collapse_cens.output.renamed_cens_key,
     output:

--- a/workflow/rules/7-fix_cens_w_repeatmasker.smk
+++ b/workflow/rules/7-fix_cens_w_repeatmasker.smk
@@ -90,7 +90,7 @@ rule rename_reort_asm:
     input:
         fa=rules.concat_asm.output.fa,
         idx=rules.concat_asm.output.idx,
-        cens_bed=rules.make_complete_cens_bed.output,
+        cens_bed=ancient(rules.make_complete_cens_bed.output),
     output:
         fa=join(
             CONCAT_ASM_OUTDIR,
@@ -130,8 +130,8 @@ rule rename_reort_asm:
 rule fix_cens_rm_out:
     input:
         script=workflow.source_path("../scripts/rename_reorient_rm_out.py"),
-        rm_rename_key=rules.make_complete_cens_bed.output,
-        rm_out=rules.format_repeatmasker_output.output,
+        rm_rename_key=ancient(rules.make_complete_cens_bed.output),
+        rm_out=ancient(rules.format_repeatmasker_output.output),
     output:
         corrected_rm_out=join(
             FIX_RM_OUTDIR,
@@ -226,7 +226,6 @@ rule plot_fixed_rm_bed_by_chr:
 
 rule fix_cens_w_repeatmasker_all:
     input:
-        expand(rules.make_complete_cens_bed.output, sm=SAMPLE_NAMES),
         expand(rules.rename_reort_asm.output, sm=SAMPLE_NAMES),
         expand(rules.plot_fixed_rm_bed_by_chr.output, chr=CHROMOSOMES),
     default_target: True

--- a/workflow/rules/7-fix_cens_w_repeatmasker.smk
+++ b/workflow/rules/7-fix_cens_w_repeatmasker.smk
@@ -58,10 +58,6 @@ def cen_status(wc):
     fa_glob_pattern = join(outdir, "{fname}.fa")
     wcs = glob_wildcards(fa_glob_pattern)
     fnames = wcs.fname
-    assert (
-        len(fnames) != 0
-    ), f"No fasta files found for repeatmasker in {fa_glob_pattern}"
-
     return expand(rules.check_cens_status.output, sm=wc.sm, fname=fnames)
 
 

--- a/workflow/rules/8-cdr_finder.smk
+++ b/workflow/rules/8-cdr_finder.smk
@@ -73,7 +73,7 @@ use rule * from CDR_Align as cdr_aln_*
 rule get_original_coords:
     input:
         # (sample_chr_ctg, st, end, is-misassembled)
-        bed=rules.make_complete_cens_bed.output,
+        bed=ancient(rules.make_complete_cens_bed.output),
         asm_faidx=rules.concat_asm.output.idx,
     output:
         og_coords=join(

--- a/workflow/rules/8-cdr_finder.smk
+++ b/workflow/rules/8-cdr_finder.smk
@@ -112,7 +112,7 @@ rule get_original_coords:
 
 # Pass CDR config here.
 CDR_FINDER_CONFIG = {
-    **config["cdr_finder"],
+    "output_dir": CDR_FINDER_OUTDIR,
     "log_dir": CDR_FINDER_LOGDIR,
     "benchmark_dir": CDR_FINDER_BMKDIR,
     "restrict_alr": True,
@@ -126,6 +126,7 @@ CDR_FINDER_CONFIG = {
         }
         for sm in SAMPLE_NAMES_INTERSECTION
     },
+    **config["cdr_finder"],
 }
 
 

--- a/workflow/rules/8-humas_sd.smk
+++ b/workflow/rules/8-humas_sd.smk
@@ -105,6 +105,7 @@ def humas_sd_sm_outputs(wc):
 checkpoint run_humas_sd:
     input:
         rules.cens_generate_monomers.output,
+        expand(rules.split_cens_for_humas_sd.output, sm=SAMPLE_NAMES),
         unpack(humas_sd_sm_outputs),
     output:
         touch(join(HUMAS_SD_OUTDIR, "humas_sd_{sm}.done")),
@@ -144,8 +145,4 @@ rule humas_sd_all:
     input:
         rules._force_humas_sd_env_inclusion.output if IS_CONTAINERIZE_CMD else [],
         expand(rules.run_humas_sd.output, sm=SAMPLE_NAMES),
-
-
-rule humas_sd_split_cens_only:
-    input:
-        expand(rules.split_cens_for_humas_sd.output, sm=SAMPLE_NAMES),
+    default_target: True

--- a/workflow/rules/8-humas_sd.smk
+++ b/workflow/rules/8-humas_sd.smk
@@ -13,7 +13,7 @@ HUMAS_SD_BMKDIR = join(BMK_DIR, "8-humas_sd")
 rule extract_cens_for_humas_sd:
     input:
         fa=rules.rename_reort_asm.output.fa,
-        bed=rules.make_complete_cens_bed.output,
+        bed=ancient(rules.make_complete_cens_bed.output),
     output:
         seq=temp(
             join(

--- a/workflow/rules/8-nucflag.smk
+++ b/workflow/rules/8-nucflag.smk
@@ -149,7 +149,7 @@ rule format_rm_nucflag_ignore_bed:
 rule format_stv_nucflag_ignore_bed:
     input:
         stv=humas_sd_sm_outputs,
-        bed=rules.make_complete_cens_bed.output,
+        bed=ancient(rules.make_complete_cens_bed.output),
         ignore_bed=(
             config["nucflag"]["ignore_regions"]
             if config["nucflag"].get("ignore_regions")
@@ -216,7 +216,7 @@ NUCFLAG_CFG = {
                 }
             ),
             "config": config["nucflag"]["config_nucflag"],
-            "region_bed": rules.make_complete_cens_bed.output,
+            "region_bed": ancient(rules.make_complete_cens_bed.output),
             # Ignore regions.
             "ignore_bed": ignore_regions,
             "overlay_beds": overlay_beds,

--- a/workflow/rules/9-get_complete_correct_cens.smk
+++ b/workflow/rules/9-get_complete_correct_cens.smk
@@ -14,7 +14,7 @@ if config.get("nucflag"):
 rule get_complete_correct_cens_bed:
     input:
         # (name, st, end, is_partial, ctg_name, ctg_len)
-        interm_bed=rules.make_complete_cens_bed.output,
+        interm_bed=ancient(rules.make_complete_cens_bed.output),
         # (name, st, end, status)
         nucflag_bed=(
             rules.check_asm_nucflag.output.asm_status if config.get("nucflag") else []


### PR DESCRIPTION
* Fixed incorrect input for RM split. (6eec17c4450ad916d4e17b8df8951667e5560faa)
* Fixed incorrect benchmark dir for concat_asm. (6eec17c4450ad916d4e17b8df8951667e5560faa)
* Fixed rules being rerun with ancient. (5576b06b82637d611e9530d3fa7d056a60502829)
* Fixed incorrect CDR-Finder output dir. (45b283e7f0eff30ab5e8432b94058daac537a8bc)
* Fixed missing rule input for HumAS-SD causing checkpoint to finish early. (d0fe61bb4abff90e38df3457664ca0e28118aa90)
* Removed file assertions which cause snakemake's `--touch` to fail. (6eec17c4450ad916d4e17b8df8951667e5560faa)
* Changed name of dna-brnn rule. (debf1ae4ec9b3ccc371f3b19b23b2536884b732d)