### PR TITLE
bugfix: chr pattern and stricter live overlap

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,8 @@
 test/data/assemblies/HG00731/HG00731_chrY_h2tg000043l.fasta.gz filter=lfs diff=lfs merge=lfs -text
+test/data/assemblies/mGorGor1/chr16_mat_hsa15.fasta.gz filter=lfs diff=lfs merge=lfs -text
 test/data/raw_data/HG00731/HG00731_chrY_h2tg000043l_reads.fastq.gz filter=lfs diff=lfs merge=lfs -text
-test/data/reference/T2T-CHM13v2_chrY.fasta.gz filter=lfs diff=lfs merge=lfs -text
 test/data/raw_data/mGorGor1/reads.bam filter=lfs diff=lfs merge=lfs -text
-test/data/assemblies/mGorGor1/chr16.fasta.gz filter=lfs diff=lfs merge=lfs -text
+test/data/reference/T2T-CHM13v2_chrY.fasta.gz filter=lfs diff=lfs merge=lfs -text
 test/format_rm_sat_annot/input/HG00731_correct_ALR_regions.fa.reformatted.out filter=lfs diff=lfs merge=lfs -text
 test/format_rm_sat_annot/expected/HG00731_correct_ALR_regions.fa.reformatted.bed filter=lfs diff=lfs merge=lfs -text
 test/map_chroms/input/HG008-N.bed filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Install Snakemake
         run: |
-          pip install -r <(yq -r '.dependencies[] | select(type == "!!map") | to_entries[].value[]' test/env_dev.yaml | grep snakemake)
+          pip install snakemake
 
       - name: Generate Dockerfile
         id: dockerfile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,6 +150,7 @@ jobs:
         -s HG00731 \
         -p 4 \
         --chromosomes chrY
+        rm -rf results logs benchmarks .snakemake/metadata
     - name: Test chrY workflow with no reference via cenmap wrapper script.
       run: |
         ./cenmap \

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ Rplots.pdf
 progress
 run.sh
 *_working
+SG_*
+all_*

--- a/cenmap
+++ b/cenmap
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Iterable
 from snakemake.utils import validate
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 # Follow symlinks to install dir.
 WD = Path(__file__).resolve().parent

--- a/test/data/assemblies/mGorGor1/chr16.fasta.gz
+++ b/test/data/assemblies/mGorGor1/chr16.fasta.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:79c4faa9084a10d3c70a5de53eb658672bb633ae787fa27ba7ffd717b00b416d
-size 707102

--- a/test/data/assemblies/mGorGor1/chr16_mat_hsa15.fasta.gz
+++ b/test/data/assemblies/mGorGor1/chr16_mat_hsa15.fasta.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93edeff89646dddc14cf874b6516b009064d3fb6ae3ff7049d28922f7068410f
+size 408448

--- a/workflow/rules/10-format_hor_stv.smk
+++ b/workflow/rules/10-format_hor_stv.smk
@@ -9,7 +9,8 @@ FMT_HOR_STV_LOGDIR = join(LOG_DIR, "10-format_hor_stv")
 
 checkpoint aggregate_format_all_stv_row:
     input:
-        humas_annot_chr_outputs,
+        # Need ancient despite not modifying any files. Snakemake retriggers run for some reason.
+        ancient(humas_annot_chr_outputs),
     output:
         join(FMT_HOR_STV_OUTDIR, "bed", "{chr}", "stv_all.bed"),
     log:

--- a/workflow/rules/11-moddotplot.smk
+++ b/workflow/rules/11-moddotplot.smk
@@ -177,14 +177,9 @@ rule plot_cen_moddotplot:
 # https://stackoverflow.com/a/63040288
 def moddotplot_outputs(wc):
     # Wait until done.
-    try:
-        _ = checkpoints.aggregate_format_all_stv_row.get(**wc).output
-    except AttributeError:
-        pass
-
+    _ = checkpoints.aggregate_format_all_stv_row.get(**wc).output
     fastas = glob.glob(join(HUMAS_CENS_SPLIT_DIR, "*.fa"))
     fnames = get_valid_fnames(fastas, filter_chrom=wc.chr if wc.chr != "all" else None)
-
     return dict(
         moddotplot=expand(rules.run_moddotplot.output, chr=wc.chr, fname=fnames),
         cen_moddoplot=expand(

--- a/workflow/rules/3-srf.smk
+++ b/workflow/rules/3-srf.smk
@@ -52,8 +52,8 @@ use rule * from srf_sm as srf_*
 
 checkpoint extract_filter_monomers:
     input:
-        paf=rules.srf_map_motifs.output,
-        monomers=rules.srf_get_monomers.output,
+        paf=ancient(rules.srf_map_motifs.output),
+        monomers=ancient(rules.srf_get_monomers.output),
     output:
         bed_mon=join(
             SRF_OUTDIR,

--- a/workflow/rules/6-repeatmasker.smk
+++ b/workflow/rules/6-repeatmasker.smk
@@ -174,7 +174,7 @@ def refmt_rm_output(wc):
         expand(rules.split_cens_for_rm.output, sm=wc.sm)[0], "{fname}.fa"
     )
     wcs = glob_wildcards(fa_glob_pattern)
-    fnames = get_valid_fnames(wcs.fname, filter_chrom=None)
+    fnames = wcs.fname
     files = expand(rules.reformat_repeatmasker_output.output, sm=wc.sm, fname=fnames)
     if not files:
         raise RuntimeError(f"No {wc.sm} centromeres found.")

--- a/workflow/rules/8-cdr_finder.smk
+++ b/workflow/rules/8-cdr_finder.smk
@@ -186,7 +186,7 @@ rule intersect_cdr_w_live:
         # Then filter based on intersect with live HOR if either stringdecomposer of humas_hmmer. i.e. human
         # Require CDR to have 90% overlap with live HOR annotation.
         cmd_intersect=lambda wc: (
-            cmd_intersect_live(Wildcards(fromdict=dict(sm=wc.sample)), ovl_frac=0.9)
+            cmd_intersect_live(Wildcards(fromdict=dict(sm=wc.sample)), ovl_frac=0.5)
             if "cmd_intersect_live" in globals()
             else ""
         ),

--- a/workflow/rules/8-cdr_finder.smk
+++ b/workflow/rules/8-cdr_finder.smk
@@ -184,8 +184,9 @@ rule intersect_cdr_w_live:
         ),
     params:
         # Then filter based on intersect with live HOR if either stringdecomposer of humas_hmmer. i.e. human
+        # Require CDR to have 90% overlap with live HOR annotation.
         cmd_intersect=lambda wc: (
-            cmd_intersect_live(Wildcards(fromdict=dict(sm=wc.sample)))
+            cmd_intersect_live(Wildcards(fromdict=dict(sm=wc.sample)), ovl_frac=0.9)
             if "cmd_intersect_live" in globals()
             else ""
         ),

--- a/workflow/rules/8-cdr_finder.smk
+++ b/workflow/rules/8-cdr_finder.smk
@@ -186,7 +186,9 @@ rule intersect_cdr_w_live:
         # Then filter based on intersect with live HOR if either stringdecomposer of humas_hmmer. i.e. human
         # Require CDR to have 90% overlap with live HOR annotation.
         cmd_intersect=lambda wc: (
-            cmd_intersect_live(Wildcards(fromdict=dict(sm=wc.sample)), ovl_frac=0.9)
+            cmd_intersect_live(
+                Wildcards(fromdict=dict(sm=wc.sample)), bp_merge=1, ovl_frac=0.9
+            )
             if "cmd_intersect_live" in globals()
             else ""
         ),

--- a/workflow/rules/8-cdr_finder.smk
+++ b/workflow/rules/8-cdr_finder.smk
@@ -186,9 +186,7 @@ rule intersect_cdr_w_live:
         # Then filter based on intersect with live HOR if either stringdecomposer of humas_hmmer. i.e. human
         # Require CDR to have 90% overlap with live HOR annotation.
         cmd_intersect=lambda wc: (
-            cmd_intersect_live(
-                Wildcards(fromdict=dict(sm=wc.sample)), bp_merge=1, ovl_frac=0.9
-            )
+            cmd_intersect_live(Wildcards(fromdict=dict(sm=wc.sample)), ovl_frac=0.9)
             if "cmd_intersect_live" in globals()
             else ""
         ),

--- a/workflow/rules/8-humas_annot.smk
+++ b/workflow/rules/8-humas_annot.smk
@@ -257,7 +257,7 @@ rule sm_stv:
             $7=$7+mtches[2];
             $8=$8+mtches[2];
             print
-        }}' {input} > {output}
+        }}' {input} | sort -k1,1 -k2,2n > {output}
         """
 
 

--- a/workflow/rules/8-humas_annot.smk
+++ b/workflow/rules/8-humas_annot.smk
@@ -261,7 +261,9 @@ rule sm_stv:
         """
 
 
-def cmd_intersect_live(wc, ovl_frac: float | None = None) -> str:
+def cmd_intersect_live(
+    wc, bp_merge: int | None = None, ovl_frac: float | None = None
+) -> str:
     if not IS_HUMAN_ANNOT:
         return ""
     all_live_hor = expand(rules.sm_stv.output, sm=wc.sm)[0]
@@ -269,7 +271,11 @@ def cmd_intersect_live(wc, ovl_frac: float | None = None) -> str:
     # With previous BED file, only report lines that intersect live asat.
     # This is ensured by sd and hmmer options. (Human only)
     # Also merge and require overlap fraction.
-    cmd = f"| bedtools intersect -u -a - -b <(bedtools merge -i {all_live_hor} -d 1)"
+    if bp_merge:
+        infile = f"<(bedtools merge -i {all_live_hor} -d {bp_merge})"
+    else:
+        infile = all_live_hor
+    cmd = f"| bedtools intersect -u -a - -b {infile}"
     if ovl_frac:
         cmd += f" -f {ovl_frac}"
     return cmd

--- a/workflow/rules/8-humas_annot.smk
+++ b/workflow/rules/8-humas_annot.smk
@@ -245,10 +245,11 @@ rule sm_stv:
     output:
         join(HUMAS_ANNOT_OUTDIR, "{sm}_live_stv.bed"),
     conda:
-        "../envs/tools.yaml"
+        "../envs/py.yaml"
     shell:
         """
-        awk -v OFS="\\t" '{{
+        censtats length \
+        -i <(awk -v OFS="\\t" '{{
             if ($4 !~ "L") {{ next }}
             match($1, "^(.+):(.+)-", mtches);
             $1=mtches[1];
@@ -257,25 +258,18 @@ rule sm_stv:
             $7=$7+mtches[2];
             $8=$8+mtches[2];
             print
-        }}' {input} | sort -k1,1 -k2,2n > {output}
+        }}' {input} | sort -k1,1 -k2,2n) > {output}
         """
 
 
-def cmd_intersect_live(
-    wc, bp_merge: int | None = None, ovl_frac: float | None = None
-) -> str:
+def cmd_intersect_live(wc, ovl_frac: float | None = None) -> str:
     if not IS_HUMAN_ANNOT:
         return ""
     all_live_hor = expand(rules.sm_stv.output, sm=wc.sm)[0]
     assert len(all_live_hor) != 0, "No live HOR to intersect against bed file."
     # With previous BED file, only report lines that intersect live asat.
     # This is ensured by sd and hmmer options. (Human only)
-    # Also merge and require overlap fraction.
-    if bp_merge:
-        infile = f"<(bedtools merge -i {all_live_hor} -d {bp_merge})"
-    else:
-        infile = all_live_hor
-    cmd = f"| bedtools intersect -u -a - -b {infile}"
+    cmd = f"| bedtools intersect -u -a - -b {all_live_hor}"
     if ovl_frac:
         cmd += f" -f {ovl_frac}"
     return cmd

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -38,50 +38,21 @@ class SplitFilename(NamedTuple):
 def get_valid_fnames(
     fastas: list[str], *, filter_chrom: str | None
 ) -> list[SplitFilename]:
-    fname_elems = []
+    fnames = []
     for fasta in fastas:
         bname, _ = splitext(basename(fasta))
         fname, coord = bname.rsplit(":", 1)
         if filter_chrom:
             sm, chrom, ctg = RGX_SM_CHR_CTG.search(fname).groups()
-        else:
-            sm, ctg = RGX_SM_CTG.search(fname).groups()
-            chrom = None
-        if chrom:
-            elems = (sm, chrom, ctg, coord)
-        else:
-            elems = (sm, ctg, coord)
-        fname_elems.append(elems)
-
-    fnames = []
-    sort_key = lambda x: (x[1], x[2], x[3]) if filter_chrom else (x[1], x[2])
-    # Sort by coords so if multiple chr, chr position in name (chr3-chr21) matches.
-    sorted_wcs = sorted(
-        fname_elems,
-        key=sort_key,
-        reverse=True,
-    )
-
-    # Store index of chrom per contig.
-    # In cases of dicentric contigs (chr3-chr21). Don't want to include twice.
-    ctg_counter = Counter()
-    for elems in sorted_wcs:
-        if filter_chrom:
-            sm, chrom, ctg, coord = elems
             chrom_names: list[str] = chrom.replace("rc-", "").split("-")
         else:
-            sm, ctg, coord = elems
+            sm, ctg = RGX_SM_CTG.search(fname).groups()
             chrom = None
             chrom_names = []
 
         if filter_chrom and not filter_chrom in chrom_names:
             continue
 
-        ctg_id = (sm, chrom, ctg, coord)
-        idx = ctg_counter[ctg_id]
-        ctg_counter[ctg_id] += 1
-        if filter_chrom and filter_chrom != chrom_names[idx]:
-            continue
         fnames.append(SplitFilename(sm=sm, chrom=chrom, ctg=ctg, coord=coord))
 
     return fnames

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -38,6 +38,16 @@ class SplitFilename(NamedTuple):
 def get_valid_fnames(
     fastas: list[str], *, filter_chrom: str | None
 ) -> list[SplitFilename]:
+    """
+    Extract wildcards and filter fasta list for chrom.
+
+    # Args
+    * fastas - list of fasta files. must have file extension. ex. {fname}.fa
+    * filter_chrom - chrom to filter for.
+
+    # Returns
+    * list of SplitFilenames
+    """
     fnames = []
     for fasta in fastas:
         bname, _ = splitext(basename(fasta))

--- a/workflow/rules/constants.smk
+++ b/workflow/rules/constants.smk
@@ -32,9 +32,9 @@ SAMPLE_NAMES = config["samples"]
 RGX_CHR = re.compile(r"(chr[0-9XY]+)")
 RGX_SM_CTG = re.compile(r"^(.+)_(.+)$")
 # This monstrosity matches the expected patterns.
-# https://regex101.com/r/qmBC6h/1
+# https://regex101.com/r/u4A2Xj/1
 RGX_SM_CHR_CTG = re.compile(
-    r"^(.+)_((?:(?:(?:chr|rc-chr)[0-9XY]+)-)*(?:(?:chr|rc-chr)[0-9XY]+))_(.+)$"
+    r"^(.*?)_((?:(?:(?:chr|rc-chr)[0-9XY]+)-)*(?:(?:chr|rc-chr)[0-9XY]+))_(.+)$"
 )
 
 # Check if command is to containerize workflow.

--- a/workflow/scripts/plot_hor_length.py
+++ b/workflow/scripts/plot_hor_length.py
@@ -213,7 +213,7 @@ def main():
         }
         handles_labels = ax.get_legend_handles_labels()
         handles, labels = zip(
-            *sorted(zip(*handles_labels), key=lambda x: legend_elem_order[x[1]])
+            *sorted(zip(*handles_labels), key=lambda x: legend_elem_order.get(x[1], -1))
         )
 
         # Place outside of figure.


### PR DESCRIPTION
* Fixed regex pattern for chrom which missed a few edge cases. (8cea05f1dc28190bcd322b6fddf5b5781b0dcc0d)
* Fixed skipping test in wrapper CI workflow. (0c9153e1f6de78442fdcd7e93ea963a224a5996a)
* Fixed using `get_valid_fnames` in RM workflow which expects fasta file input. (fac15dfbab24d446b374d9a7d39956b1f4a1ab18)
* Fixed CDR false-positives with overlapping live HOR by adding minimum 50% overlap. (6865e86adb95d99f317a36da191e6c35525a97cf)
* Fixed CI workflow not installing `Snakemake` for Dockerfile building.
* Fixed `KeyError` in plot_hor_length workflow. (2e18f048c67221076318705de86647a930537e2a)
* Removed checks in `get_valid_fnames` causing certain chrom patterns to be removed; however, this causes centromeres with multiple chromosome alignments to be plotted multiple times. (8cea05f1dc28190bcd322b6fddf5b5781b0dcc0d)
* Removed unused haplotype in test mGorGor1 fasta. (8cea05f1dc28190bcd322b6fddf5b5781b0dcc0d)
* Changed live merge tool to `censtats length` instead of `bedtools merge`. (aec8bc67aab380dcf856f81b8b48bab734827e0b)