### PR TITLE
feat/bugfix: omit entropy filter + cdr-finder fixes

### DIFF
--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -454,9 +454,6 @@ properties:
         description: "Use HOR annotation to filter CDRs.\n\n
           * Only applied to human annotation modes, `sd` and `hmmer`."
         default: true
-    required:
-      - input_bam_dir
-      - bam_rgx
   get_complete_correct_cens:
     type: object
     additionalProperties: false

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -215,6 +215,10 @@ properties:
         type: boolean
         description: Omit entropy plots.
         default: true
+      omit_entropy_filter:
+        type: boolean
+        description: Remove entropy filter. Only for RepeatMasker-based version.
+        default: false
       trim_to_repeats:
         type: array
         items:

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -434,6 +434,10 @@ properties:
         type: number
         description: Baseline expected average methylation. Scales thresholds if average methylation is below value, reducing false positives.
         default: 0.4
+      rolling_mean_window:
+        type: integer
+        description: Apply a rolling mean window over CpG signal. Helps in improving CDR calling in less prominent CDRs.
+        default: 3
       use_srf_regions:
         type: boolean
         description: "Use `srf-n-trf` regions instead of `RepeatMasker` output as putative alpha-satellite region.\n\n

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -111,6 +111,6 @@ cdr_finder:
   alr_threshold: 100000
   bp_alr_merge: 8000
   bp_edge: 500_000
-  height_perc_valley_threshold: 0.34
-  prom_perc_valley_threshold: 0.3
+  height_perc_valley_threshold: 0.2
+  prom_perc_valley_threshold: 0.1
   extend_edges_std: -1

--- a/config/config_no_ref.yaml
+++ b/config/config_no_ref.yaml
@@ -82,6 +82,6 @@ cdr_finder:
   alr_threshold: 100000
   bp_alr_merge: 8000
   bp_edge: 500_000
-  height_perc_valley_threshold: 0.34
-  prom_perc_valley_threshold: 0.3
+  height_perc_valley_threshold: 0.2
+  prom_perc_valley_threshold: 0.1
   extend_edges_std: -1

--- a/config/config_tumor.yaml
+++ b/config/config_tumor.yaml
@@ -115,6 +115,6 @@ cdr_finder:
   alr_threshold: 100000
   bp_alr_merge: 8000
   bp_edge: 500_000
-  height_perc_valley_threshold: 0.34
-  prom_perc_valley_threshold: 0.3
+  height_perc_valley_threshold: 0.2
+  prom_perc_valley_threshold: 0.1
   extend_edges_std: -1

--- a/workflow/rules/11-calculate_hor_length.smk
+++ b/workflow/rules/11-calculate_hor_length.smk
@@ -21,6 +21,7 @@ rule calculate_as_hor_length:
             "{chr}_AS-HOR_lengths.bed",
         ),
     params:
+        # TODO: censtats length should be modified to look at active SF classes (SF1, SF2, SF3, SF01, etc.) if not using sd.
         length_params=(
             "--allow_nonlive -mu 100000 -mb 100000 -ua 0 -ub 0 -fp 0.0 -fl 0"
             if config["humas_annot"]["mode"] not in ["sd", "hmmer"]

--- a/workflow/rules/7.1-fix_cens_w_repeatmasker.smk
+++ b/workflow/rules/7.1-fix_cens_w_repeatmasker.smk
@@ -80,12 +80,33 @@ rule filter_entropy_bed:
         """
 
 
+rule no_filter_entropy:
+    output:
+        bed=temp(
+            join(
+                FIX_RM_OUTDIR,
+                "entropy",
+                "interm",
+                "{sm}_{fname}_noop.bed",
+            )
+        ),
+    run:
+        ctg, coords = wildcards.fname.rsplit(":", 1)
+        st, end = coords.split("-")
+        with open(str(output.bed), "wt") as fh:
+            print(ctg, st, end, str(wildcards.fname), sep="\t", file=fh)
+
+
 def valid_beds_by_cen_entropy(wc):
     outdir = checkpoints.split_cens_for_rm.get(**wc).output[0]
     fa_glob_pattern = join(outdir, "{fname}.fa")
     wcs = glob_wildcards(fa_glob_pattern)
     fnames = wcs.fname
-    return expand(rules.filter_entropy_bed.output, sm=wc.sm, fname=fnames)
+
+    if config["repeatmasker"].get("omit_entropy_filter"):
+        return expand(rules.no_filter_entropy.output, sm=wc.sm, fname=fnames)
+    else:
+        return expand(rules.filter_entropy_bed.output, sm=wc.sm, fname=fnames)
 
 
 # Merge complete centromere coordinates. Prior to running NucFlag.

--- a/workflow/rules/7.1-fix_cens_w_repeatmasker.smk
+++ b/workflow/rules/7.1-fix_cens_w_repeatmasker.smk
@@ -113,7 +113,7 @@ def valid_beds_by_cen_entropy(wc):
 rule make_complete_cens_bed:
     input:
         # (sm_ctg, st, end, old_sm_ctg)
-        beds=valid_beds_by_cen_entropy,
+        beds=ancient(valid_beds_by_cen_entropy),
         # (ctg, sm_ctg, ctg_len)
         rename_key=rules.create_rename_key.output,
         idx=rules.create_final_asm.output.idx,

--- a/workflow/rules/7.1-fix_cens_w_repeatmasker.smk
+++ b/workflow/rules/7.1-fix_cens_w_repeatmasker.smk
@@ -86,8 +86,8 @@ rule no_filter_entropy:
             join(
                 FIX_RM_OUTDIR,
                 "entropy",
-                "interm",
-                "{sm}_{fname}_noop.bed",
+                "interm_noop",
+                "{sm}_{fname}.bed",
             )
         ),
     run:

--- a/workflow/rules/8-cdr_finder.smk
+++ b/workflow/rules/8-cdr_finder.smk
@@ -10,13 +10,21 @@ if IS_HUMAN_ANNOT:
 
 
 # Get sample names with subdirs in cdr_finder.input_bam_dir
-SAMPLE_NAMES_BAM = set(
-    glob_wildcards(join(config["cdr_finder"]["input_bam_dir"], "{sm}")).sm
-)
+if config["cdr_finder"].get("input_bam_fofn_dir"):
+    glob_sm = join(config["cdr_finder"]["input_bam_fofn_dir"], "{sm}.fofn")
+    cfg_cdr_aln = lambda sm: {"read_fofn": glob_sm.format(sm=sm)}
+else:
+    glob_sm = join(config["cdr_finder"]["input_bam_dir"], "{sm}")
+    cfg_cdr_aln = lambda sm: {
+        "read_dir": glob_sm.format(sm=sm),
+        "read_rgx": config["cdr_finder"]["bam_rgx"],
+    }
+
+SAMPLE_NAMES_BAM = set(glob_wildcards(glob_sm).sm)
 SAMPLE_NAMES_INTERSECTION = SAMPLE_NAMES_BAM.intersection(set(SAMPLE_NAMES))
 print(
     f"Using {len(SAMPLE_NAMES_INTERSECTION)} out of {len(SAMPLE_NAMES)} samples "
-    f"that have subdirs in {config['cdr_finder']['input_bam_dir']} for CDR-Finder.",
+    f"that have match {glob_sm} for CDR-Finder.",
     file=sys.stderr,
 )
 ALIGNER = config["cdr_finder"].get("aligner", "minimap2")
@@ -47,18 +55,7 @@ CDR_ALIGN_CFG = {
         {
             "name": sm,
             "asm_fa": expand(rules.create_final_asm.output.fa, sm=sm)[0],
-            **(
-                {
-                    "read_fofn": join(
-                        config["cdr_finder"]["input_bam_fofn_dir"], f"{sm}.fofn"
-                    ),
-                }
-                if config["cdr_finder"].get("input_bam_fofn_dir")
-                else {
-                    "read_dir": join(config["cdr_finder"]["input_bam_dir"], sm),
-                    "read_rgx": config["cdr_finder"]["bam_rgx"],
-                }
-            ),
+            **cfg_cdr_aln(sm),
         }
         for sm in SAMPLE_NAMES_INTERSECTION
     ],

--- a/workflow/rules/8-humas_annot.smk
+++ b/workflow/rules/8-humas_annot.smk
@@ -231,7 +231,7 @@ def humas_annot_sm_outputs(wc):
 
 rule sm_stv:
     input:
-        humas_annot_sm_outputs,
+        ancient(humas_annot_sm_outputs),
     output:
         join(HUMAS_ANNOT_OUTDIR, "{sm}_live_stv.bed"),
     conda:
@@ -272,7 +272,7 @@ checkpoint run_humas_annot:
             if config["humas_annot"]["mode"] != "srf-n-trf"
             else []
         ),
-        humas_annot_sm_outputs,
+        ancient(humas_annot_sm_outputs),
         rules.sm_stv.output if IS_HUMAN_ANNOT else [],
     output:
         touch(join(HUMAS_ANNOT_OUTDIR, "humas_annot_{sm}.done")),

--- a/workflow/rules/8-nucflag.smk
+++ b/workflow/rules/8-nucflag.smk
@@ -169,6 +169,8 @@ else:
     ignore_regions = str(rules.create_rm_nucflag_ignore_bed.output)
     overlay_beds = [str(rules.create_rm_overlay_bed.output)]
 
+
+# TODO: Integrate NucFlag v1.0
 NUCFLAG_CFG = {
     "samples": [
         {


### PR DESCRIPTION
* Added option to remove entropy filter from RepeatMasker workflow.
* Added option to modify CDR-Finder's rolling_mean_window parameter.
* Changed CDR-Finder workflow to round coordinates instead of floor/ceil.
* Fixed requiring CDR-Finder input_bam_dir.
* Fixed debug plots in CDR-Finder to plot after coordinate merge adjustment and use bar instead of fill_between.