### PR TITLE
feat: set percent valid in partial detection

### DIFF
--- a/cenmap
+++ b/cenmap
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Iterable
 from snakemake.utils import validate
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 # Follow symlinks to install dir.
 WD = Path(__file__).resolve().parent

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -128,6 +128,10 @@ properties:
         type: integer
         description: Add n base pairs to extend edges of query HOR array.
         default: 1000000
+      perc_valid:
+        type: number
+        description: "Percentage of putative alpha-satellite array covered by low entropy to consider complete."
+        default: 0.9
       perc_mon_len_diff:
         type: number
         # TODO: Tune more (2.0 > 1.0). Some HSAT-1A contains trf monomers that are close (168).
@@ -211,6 +215,10 @@ properties:
         description: "Window size to use in calculating shannon index for region filtering.\n\n
           * Smaller windows allow smaller centromeres but may increase the number of false-positives. (ex. monomeric/divergent alpha-satellite or p-arm fragments of acrocentric chromosomes)"
         default: 5000
+      perc_valid:
+        type: number
+        description: "Percentage of alpha-satellite array covered by low entropy to consider complete."
+        default: 0.9
       omit_shannon_plots:
         type: boolean
         description: Omit entropy plots.

--- a/workflow/rules/7.1-fix_cens_w_kmers.smk
+++ b/workflow/rules/7.1-fix_cens_w_kmers.smk
@@ -61,12 +61,14 @@ rule filter_entropy_bed:
     params:
         script=workflow.source_path("../scripts/filter_entropy_bed_kmers.py"),
         bp_merge=config["ident_cen_ctgs"]["bp_merge"],
+        perc_valid=config["ident_cen_ctgs"]["perc_valid"],
     conda:
         "../envs/py.yaml"
     shell:
         """
         python {params.script} \
         -i <(cat {input.entropy_dir}/*.bed) \
+        -p {params.perc_valid} \
         -b {input.putative_alr_bed} \
         -d {params.bp_merge} > {output} 2> {log}
         """

--- a/workflow/rules/7.1-fix_cens_w_repeatmasker.smk
+++ b/workflow/rules/7.1-fix_cens_w_repeatmasker.smk
@@ -68,6 +68,7 @@ rule filter_entropy_bed:
             else ""
         ),
         bp_merge=config["ident_cen_ctgs"]["bp_merge"],
+        perc_valid=config["repeatmasker"]["perc_valid"],
     conda:
         "../envs/py.yaml"
     shell:
@@ -75,6 +76,7 @@ rule filter_entropy_bed:
         python {params.script} \
         -i {input.entropy_bed} \
         -r {input.rm_out} \
+        -p {params.perc_valid} \
         {params.trim_to_repeats} \
         -d {params.bp_merge} > {output} 2> {log}
         """

--- a/workflow/scripts/filter_entropy_bed.py
+++ b/workflow/scripts/filter_entropy_bed.py
@@ -77,7 +77,7 @@ def main():
         "-p",
         "--prop_valid",
         type=float,
-        default=0.99,
+        default=0.9,
         help="Proportion of dips in entropy over all evaluated repeat regions required to be valid.",
     )
     ap.add_argument(


### PR DESCRIPTION
* Allow setting the percent valid and drop to 90% by default to recover poorly-assembled acrocentric cases.
* Bump version to v1.2.1